### PR TITLE
chore: ignore local editor config and binary artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ out/
 .DS_Store
 .vscode-test/
 *.vsix
+
+# Local-only editor / binary artifacts
+.vscode/mcp.json
+*.pdf
+doc/*.png
 doc/Background-Agent-Plan.md
 doc/QA-merge-improvement.md
 doc/conflict-detection.md


### PR DESCRIPTION
Ignore per-machine / binary files that don't belong in the repo:

- `.vscode/mcp.json` — per-machine MCP server config
- `*.pdf` — reference PDFs
- `doc/*.png` — design mockups

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)