### PR TITLE
fix(kill): gracefully fall back to prune when worktree removal fails

### DIFF
--- a/packages/cli/src/commands/kill.test.ts
+++ b/packages/cli/src/commands/kill.test.ts
@@ -117,10 +117,15 @@ describe('kill', () => {
     expect(mockExit).not.toHaveBeenCalled();
   });
 
-  it('should throw when removeWorktree fails', async () => {
+  it('should gracefully handle removeWorktree failure and still clean up', async () => {
     mockGitUtils.removeWorktree.mockRejectedValue(new Error('worktree not found'));
 
-    await expect(kill(identifier, { root: rootDir })).rejects.toThrow('worktree not found');
+    // Should NOT throw — graceful fallback to prune
+    await kill(identifier, { root: rootDir });
+
+    // Should still prune and delete branch
+    expect(mockGitUtils.pruneWorktrees).toHaveBeenCalled();
+    expect(mockGitUtils.deleteBranch).toHaveBeenCalledWith('feat/old-feature', true);
   });
 
   it('should throw when deleteBranch fails for actual branch', async () => {

--- a/packages/cli/src/commands/kill.ts
+++ b/packages/cli/src/commands/kill.ts
@@ -28,9 +28,15 @@ export async function kill(identifier: string, options: { root: string; keepBran
     }
 
     // 2. Remove worktree
-    await git.removeWorktree(targetPath, true);
+    try {
+      await git.removeWorktree(targetPath, true);
+      console.log(chalk.gray('✓ Removed git worktree.'));
+    } catch {
+      // Worktree directory may already be gone (manually deleted) —
+      // fall back to prune to clean up stale git internal references.
+      console.log(chalk.gray('⚠ Worktree directory not found, pruning stale reference...'));
+    }
     await git.pruneWorktrees();
-    console.log(chalk.gray('✓ Removed git worktree.'));
 
     // 2b. Clean up residual clone directory (e.g. extension re-created files after kill)
     if (await fs.pathExists(targetPath)) {

--- a/packages/extension/src/commands/kill.ts
+++ b/packages/extension/src/commands/kill.ts
@@ -32,7 +32,7 @@ export function registerKillCommands(
             title: `Killing shadow clone: ${cloneId}`,
             cancellable: false
           }, async () => {
-            await kill(cloneId, { root: effectiveRoot!, keepBranch });
+            await kill(cloneId, { root: effectiveRoot!, keepBranch, worktreePath: item?.clone?.path });
           });
           
           const msg = keepBranch


### PR DESCRIPTION
## Problem
When a clone's worktree directory was already removed manually, `removeWorktree` threw and aborted the entire `kill` flow — leaving a stale git reference and an undeleted branch.

## Fix
- Catch the `removeWorktree` failure and fall back to `pruneWorktrees`, so cleanup (prune + branch deletion) still completes.
- The extension now passes the resolved `worktreePath` so `kill` targets the correct path.

## Tests
All 20 `kill.test.ts` tests pass. The previous "should throw when removeWorktree fails" test is replaced by "should gracefully handle removeWorktree failure and still clean up".

🤖 Generated with [Claude Code](https://claude.com/claude-code)