### PR TITLE
feat(worktree): self-tidying worktrees + decoupled metadata

### DIFF
--- a/doc/worktree-folder-cleanup-design.md
+++ b/doc/worktree-folder-cleanup-design.md
@@ -64,8 +64,18 @@ becomes `<root>/.lumi/<METADATA_FILE>`. Clones already resolve via
 `mainRepoRoot`, so they keep reading the root's metadata.
 
 ### Migration
-One-time, reuse the `migration.ts` pattern: if old
-`.worktrees/.lumi-metadata.json` exists and the new location doesn't, move it.
+One-time, idempotent `migrateMetadataToLumiDir()`: if old
+`.worktrees/.lumi-metadata.json` exists, move it (merge if both exist, new wins).
+Triggered on every surface so it can't be missed:
+- **extension** — `runMigrations()` on activation (before the first sidebar read).
+- **CLI** — start of `spawn()`.
+- **WorktreeManager** — per-repo on panel refresh.
+- **MCP** — inside the `state.ts` `readMetadata`/`writeMetadata` chokepoint, so
+  an agent driving the MCP server *standalone* (no extension activation) is
+  migrated on its first metadata access regardless of which tool it calls first.
+  (Deliberately NOT added to CLI `kill()` — that would couple kill to the heavy
+  `migration.ts` module and break its child_process test mock; spawn + the MCP
+  chokepoint already cover the agent path.)
 
 ### Call-site impact (honestly scoped)
 Most reads go through `getRepoStorageDir()` → change that **one helper** to the

--- a/doc/worktree-folder-cleanup-design.md
+++ b/doc/worktree-folder-cleanup-design.md
@@ -1,0 +1,183 @@
+# Design: Free-to-delete `.worktrees` + GC/reconcile + decoupled metadata
+
+> Status: **DESIGN / PENDING APPROVAL** (no code written yet).
+> Updated 2026-06-14 after the problem was reframed by the user.
+> Supersedes the earlier "auto-delete empty folder on last kill" framing.
+
+## 0. The real problem (reframed)
+
+The original ask ("auto-delete `.worktrees` when the last clone is killed") was
+only the surface. The actual requirements:
+
+1. **A user must be able to delete `.worktrees` directly, without worry**, if
+   they don't want it — no crash, no corrupted state, no lost durable data.
+2. **There must be a way to tidy/clear leftover worktrees** — reconcile git's
+   internal registrations and the tool's metadata after manual deletion.
+3. *(Bonus)* Auto-remove the empty `.worktrees` container too.
+
+This is **deletion-tolerance + a GC/reconcile mechanism**, not an auto-delete in
+the hot `kill` path. A user-invoked GC also **dissolves the spawn/remove TOCTOU
+race** that the auto-on-kill design could not safely close — GC runs when the
+user chooses, never concurrently with the kill flow.
+
+## 1. Why metadata ended up inside `.worktrees` (answering "why?")
+
+`constants.ts:32` comment: *"Now unified with the worktrees directory."*
+It was a **convenience co-location**: when `.worktrees/` became the standard
+per-repo location, the metadata file was put there too because it sits outside
+the repo tree (no repo pollution, no gitignore needed, never committed), one
+place per repo. It works — until you want to freely delete `.worktrees`. The
+coupling (`getRepoStorageDir === getClonesDir`) is exactly what makes the durable
+state vulnerable to a folder the user should be free to remove.
+
+## 2. The keystone: decouple metadata from `.worktrees`
+
+Moving `.lumi-metadata.json` **out** of `.worktrees` is the single change that
+makes everything else fall into place:
+
+- `rm -rf .worktrees` loses **no durable state** → true "without worry".
+- Auto-removing the empty container becomes **trivially safe** — `.worktrees`
+  then holds only worktree subdirs, so "empty" is real; the earlier
+  orphan-metadata **data-loss trap disappears entirely** (no gate (c) needed).
+- GC can reconcile cleanly: drop entries whose worktree path no longer exists,
+  **keep** annotations (baseBranch/description/status) for branches that survive.
+
+### Where to move it — DECIDED: **R = `<repoRoot>/.lumi/metadata.json`**
+
+Chosen 2026-06-14. Visible/discoverable, matches the existing `.lumi/`
+convention, minimal resolver change.
+
+**The "must be excluded or it gets committed" risk is already solved** —
+`gitExclude.ts:6` already lists `.lumi/` in the exclude patterns, and
+`ensureGitExclude()` already runs on every activation for every root
+(`extension.ts:131`), writing to `.git/info/exclude` (common dir for
+worktrees). So `<root>/.lumi/metadata.json` is git-excluded with **zero new
+work**.
+
+`.lumi/` convention after this change (consistent):
+- **clone** `.lumi/` → that clone's MISSION.md / MISSION_COMPLETE.md (`spawn.ts:144`).
+- **root** `.lumi/` → repo-level `metadata.json` (currently unused at root → safe).
+
+Implementation: change `getRepoStorageDir(rootDir)` to return
+`path.join(rootDir, '.lumi')` (decoupled from `getClonesDir`); metadata path
+becomes `<root>/.lumi/<METADATA_FILE>`. Clones already resolve via
+`mainRepoRoot`, so they keep reading the root's metadata.
+
+### Migration
+One-time, reuse the `migration.ts` pattern: if old
+`.worktrees/.lumi-metadata.json` exists and the new location doesn't, move it.
+
+### Call-site impact (honestly scoped)
+Most reads go through `getRepoStorageDir()` → change that **one helper** to the
+new location. Direct `getClonesDir(...) + METADATA_FILE` bypasses exist at
+`WorktreeManagerPanel.ts:157,229` — repoint them to `getRepoStorageDir`. Done.
+
+## 3. Phase 2 — self-tidying (FULLY AUTOMATIC, no manual button)
+
+> Decided 2026-06-14: **no manual button, no `lumi-ops gc` command in the UI.**
+> Tidying must be invisible — it just stays clean. Not a standalone "GC command";
+> instead, two safe ops folded into moments that already happen. Branches are NOT
+> in scope, no metadata is dropped.
+
+### The keystone: git already reports the condition (`prunable`)
+**Verified by experiment (2026-06-14):** after a worktree folder is manually
+deleted, `git worktree list --porcelain` STILL lists it, marked `prunable` with
+reason "gitdir file points to a non-existent location". The refresh path already
+fetches exactly this output every cycle (`ShadowTreeProvider.ts:197`
+`listWorktrees()` → `parseWorktrees`). So the condition "folder gone but git
+registration present" is **already computed by git and handed to us for free on
+every refresh** — we currently just discard the `prunable` flag
+(`parseWorktrees`, `list.ts:49-89`, never reads it).
+
+> ⚠️ Correction of an earlier claim in this doc: the sidebar does **not**
+> currently self-heal. Because `parseWorktrees` ignores `prunable` and there is
+> no `existsSync` filter anywhere in `ShadowTreeProvider`, a manually-deleted
+> worktree shows as a **ghost entry** (pointing at a non-existent path) until a
+> prune runs. That's a latent bug this refinement also fixes.
+
+### Op 1 — condition-driven prune (the better trigger)
+1. Teach `parseWorktrees` to parse the `prunable` line into a flag on each clone.
+2. In the refresh path, for `prunable` entries:
+   - **Exclude them from the displayed list** → the ghost entry disappears (the
+     behavior the user assumed already existed).
+   - **If any are present, run `git.pruneWorktrees()`** → condition-driven
+     reconcile, fired *exactly when git says something is prunable*. In steady
+     state (nothing prunable) it runs **zero** prunes — so it's free to do this
+     on the 5s poll; it is NOT a wasteful timer-prune.
+3. Keep the existing prune inside `kill()` (`kill.ts:39`) and add a cheap
+   defensive prune at the start of `spawn()` (belt-and-suspenders for
+   re-spawning a manually-deleted branch name). Activation needs no special
+   hook — the first refresh handles it.
+
+This is the user's "run prune when the condition holds" — the condition is git's
+own `prunable` flag, already in hand. It closes the "deleted while VS Code is
+open" case cleanly (the next 5s refresh detects + prunes), with no extra git
+calls in the common case.
+
+### Op 2 — remove the empty `.worktrees` container
+When **no non-prunable worktrees** remain under it. Safe now because metadata
+lives at `<root>/.lumi/` (Phase 1), so the folder is genuinely empty. Triggers:
+on `kill()` (new final step, last clone) and off the same refresh detection.
+Best-effort, non-fatal.
+
+### Why no button is correct
+Every op is safe + idempotent (prune only removes git-confirmed-`prunable`
+registrations; removing a *verified-empty* dir loses nothing) and rides on data
+the refresh already fetches. Tidying is therefore **invisible** — never a chore
+to remember. A button would frame tidying as a task; the goal is that it isn't.
+
+### Minor consideration
+`git worktree prune` removes a registration as soon as its gitdir is missing. A
+worktree on a temporarily-unmounted drive could be flagged `prunable` and
+de-registered. Niche for local dev; if it matters, prune with a small
+`--expire` grace window. Default is fine to start.
+
+### Why branches are out of scope (user's call, 2026-06-14)
+**Deleting a worktree folder ≠ wanting to delete the branch.** The branch is the
+durable work; the folder is just a checkout location. A worktree manager must
+not touch branch lifecycle. Dropped the entire "orphan branch cleanup"
+sub-feature.
+
+### Why metadata reconcile is also unnecessary
+`ShadowTreeProvider.getChildren` (`ShadowTreeProvider.ts:197-208`) lists clones
+from `git.listWorktrees()` + `parseWorktrees()` (authoritative), then only
+*enriches* each with a `metadata[dirName]` lookup. Consequences:
+- Once Op 1 excludes `prunable` entries, a deleted worktree **disappears from the
+  sidebar on the next refresh** (today it lingers as a ghost — see the Op 1
+  correction). The list is keyed off git, not metadata.
+- An orphan metadata entry (no live worktree) is **never displayed** — harmless,
+  and worth **keeping**: since the branch persists and may be re-spawned, the
+  retained entry restores baseBranch/description context on re-spawn.
+
+Metadata entries are therefore removed **only on explicit `kill`** (current
+behavior). Manual folder deletion leaves them (invisible + re-spawnable).
+
+## 4. Phase 3 — deletion-tolerance hardening (release hygiene, not the user's pain)
+
+On **macOS** (the user's platform), deleting a watched dir typically makes the
+`fs.watch` go inert, not crash — so the user's symptom of a manual delete is
+**stale state** (ghost sidebar entries, stale git regs), which Phase 2 fixes.
+The crash matters for **Linux/Windows** users you ship to:
+- Add `.on('error', () => {})` to `fs.watch` sites: `extension.ts:286/302`,
+  `WorktreeManagerPanel.ts:286`, `autoCloseWatcher.ts:39`.
+- Stop eager `mkdirSync(clonesDir)` (`extension.ts:283`, `WorktreeManagerPanel.ts:285`);
+  arm watchers lazily (watch the parent for `.worktrees` appearing — the
+  `autoCloseWatcher.ts:35-44` pattern), so a deleted+recreated folder re-arms.
+
+## 5. Recommended sequence
+1. **Phase 1** decouple metadata (keystone) + migration.
+2. **Phase 2** GC/reconcile command (delivers the real ask).
+3. **Phase 3** watcher hardening (before any non-macOS release).
+4. Auto-clean of the empty container = a safe side-effect inside Phase 2.
+
+## 6. Decisions — RESOLVED (2026-06-14)
+1. ✅ Reframe approved: **GC/reconcile + decoupled metadata**, not auto-delete-on-kill.
+2. ✅ Metadata location: **R — `<repoRoot>/.lumi/metadata.json`** (already git-excluded; zero new work).
+3. ✅ Tidying: **fully automatic, NO manual button** — `git worktree prune` +
+   empty-folder removal folded into `kill()`, activation, and (defensive) `spawn()`.
+4. ✅ Branches: **out of scope entirely** — deleting a folder ≠ deleting a branch.
+   GC = `git worktree prune` + empty-folder removal only. No branch handling, no
+   metadata-dropping (sidebar reads from git, so orphan entries are invisible +
+   re-spawnable).
+5. ⏳ OPEN: Phase 3 watcher hardening — bundle now, or separate release-hardening pass?
+6. ⏳ Per CLAUDE.md: design-only so far; **awaiting explicit go-ahead before any code.**

--- a/packages/cli/src/__tests__/e2e.test.ts
+++ b/packages/cli/src/__tests__/e2e.test.ts
@@ -355,17 +355,29 @@ describe('e2e: kill orphan parent cleanup', () => {
     expect(await fs.pathExists(path.join(getClonesDir(tmpDir), 'feat/sibling-b'))).toBe(true);
   });
 
-  it('should NEVER delete the .worktrees root directory', async () => {
+  it('should remove the empty .worktrees root after the last clone is killed', async () => {
     await spawn('solo-branch', { root: tmpDir });
 
     await kill('solo-branch', { root: tmpDir });
 
     expect(await fs.pathExists(path.join(getClonesDir(tmpDir), 'solo-branch'))).toBe(false);
-    // The .worktrees root must NEVER be deleted
+    // The .worktrees container is now self-tidying: empty after the last kill → removed.
+    expect(await fs.pathExists(getClonesDir(tmpDir))).toBe(false);
+  });
+
+  it('should NOT remove the .worktrees root while other clones remain', async () => {
+    await spawn('keeper', { root: tmpDir });
+    await spawn('goner', { root: tmpDir });
+
+    await kill('goner', { root: tmpDir });
+
+    expect(await fs.pathExists(path.join(getClonesDir(tmpDir), 'goner'))).toBe(false);
+    // Other clone still present → container preserved.
+    expect(await fs.pathExists(path.join(getClonesDir(tmpDir), 'keeper'))).toBe(true);
     expect(await fs.pathExists(getClonesDir(tmpDir))).toBe(true);
   });
 
-  it('should handle deeply nested branch names (a/b/c) and clean all empty parents', async () => {
+  it('should handle deeply nested branch names (a/b/c) and clean all empty parents incl. root', async () => {
     await spawn('a/b/c', { root: tmpDir });
 
     await kill('a/b/c', { root: tmpDir });
@@ -373,8 +385,8 @@ describe('e2e: kill orphan parent cleanup', () => {
     expect(await fs.pathExists(path.join(getClonesDir(tmpDir), 'a/b/c'))).toBe(false);
     expect(await fs.pathExists(path.join(getClonesDir(tmpDir), 'a/b'))).toBe(false);
     expect(await fs.pathExists(path.join(getClonesDir(tmpDir), 'a'))).toBe(false);
-    // Root clones dir must survive
-    expect(await fs.pathExists(getClonesDir(tmpDir))).toBe(true);
+    // Empty root container is removed too once the last clone is gone.
+    expect(await fs.pathExists(getClonesDir(tmpDir))).toBe(false);
   });
 
   it('should only clean empty levels in partially nested structure', async () => {
@@ -401,8 +413,9 @@ describe('e2e: kill orphan parent cleanup', () => {
 
     // Parent 'chore/' should be cleaned up despite .DS_Store
     expect(await fs.pathExists(chorePath)).toBe(false);
-    // The .worktrees root must still exist
-    expect(await fs.pathExists(getClonesDir(tmpDir))).toBe(true);
+    // chore/ds-test was the only clone → the now-empty .worktrees root is
+    // self-tidied away too (a stray .DS_Store doesn't block removal).
+    expect(await fs.pathExists(getClonesDir(tmpDir))).toBe(false);
   });
 });
 

--- a/packages/cli/src/commands/kill.test.ts
+++ b/packages/cli/src/commands/kill.test.ts
@@ -280,18 +280,40 @@ describe('kill', () => {
     expect(removeCalls).not.toContain(parentPath);
   });
 
-  it('should NOT delete the clones directory root for non-nested branches', async () => {
+  it('should remove the empty clones root for a flat last branch', async () => {
     const flatIdentifier = 'mybranch';
+    const clonesDir = getClonesDir(rootDir);
     mockExecSync.mockReturnValue('mybranch\n');
+
+    // clones root has no remaining worktree subdirs → should be removed
+    mockFs.readdir.mockImplementation(async (dir: string) => {
+      if (dir === clonesDir) return [];
+      throw new Error('ENOENT');
+    });
 
     await kill(flatIdentifier, { root: rootDir });
 
-    // remove should not have been called with the clones dir
-    const removeCalls = mockFs.remove.mock.calls.map((c: any[]) => c[0]);
-    expect(removeCalls).not.toContain(getClonesDir(rootDir));
+    expect(mockFs.remove).toHaveBeenCalledWith(clonesDir);
   });
 
-  it('should handle deeply nested branch names (a/b/c)', async () => {
+  it('should NOT remove the clones root while other clones remain', async () => {
+    const flatIdentifier = 'mybranch';
+    const clonesDir = getClonesDir(rootDir);
+    mockExecSync.mockReturnValue('mybranch\n');
+
+    // another clone directory still present → root must be preserved
+    mockFs.readdir.mockImplementation(async (dir: string) => {
+      if (dir === clonesDir) return [{ name: 'other', isDirectory: () => true }];
+      throw new Error('ENOENT');
+    });
+
+    await kill(flatIdentifier, { root: rootDir });
+
+    const removeCalls = mockFs.remove.mock.calls.map((c: any[]) => c[0]);
+    expect(removeCalls).not.toContain(clonesDir);
+  });
+
+  it('should handle deeply nested branch names (a/b/c) and remove the empty root', async () => {
     const deepIdentifier = 'a/b/c';
     const clonesDir = getClonesDir(rootDir);
     const parentB = path.join(clonesDir, 'a', 'b');
@@ -299,18 +321,16 @@ describe('kill', () => {
     mockExecSync.mockReturnValue('a/b/c\n');
 
     mockFs.readdir.mockImplementation(async (dir: string) => {
-      if (dir === parentB || dir === parentA) return [];
+      if (dir === parentB || dir === parentA || dir === clonesDir) return [];
       throw new Error('ENOENT');
     });
 
     await kill(deepIdentifier, { root: rootDir });
 
-    // Both empty parents should be removed
+    // Both empty parents AND the now-empty clones root should be removed
     expect(mockFs.remove).toHaveBeenCalledWith(parentB);
     expect(mockFs.remove).toHaveBeenCalledWith(parentA);
-    // But NOT the clonesDir itself
-    const removeCalls = mockFs.remove.mock.calls.map((c: any[]) => c[0]);
-    expect(removeCalls).not.toContain(clonesDir);
+    expect(mockFs.remove).toHaveBeenCalledWith(clonesDir);
   });
 
   it('should clean up parent directory containing only .DS_Store (no subdirectories)', async () => {

--- a/packages/cli/src/commands/kill.ts
+++ b/packages/cli/src/commands/kill.ts
@@ -62,6 +62,21 @@ export async function kill(identifier: string, options: { root: string; keepBran
       }
     }
 
+    // 2d. Remove the empty .worktrees container itself when no worktrees remain.
+    //     Safe now that metadata lives in <root>/.lumi/, not inside .worktrees —
+    //     so "no worktree subdirs" means the folder is genuinely empty. Files
+    //     like .DS_Store are ignored and removed with the folder. Best-effort.
+    try {
+      const entries = await fs.readdir(clonesDir, { withFileTypes: true });
+      const hasSubdirs = entries.some((e: { isDirectory: () => boolean }) => e.isDirectory());
+      if (!hasSubdirs) {
+        await fs.remove(clonesDir);
+        console.log(chalk.gray('✓ Removed empty .worktrees container.'));
+      }
+    } catch {
+      // .worktrees already gone or unreadable — nothing to do
+    }
+
     // 3. Delete branch (unless keepBranch is set)
     if (!options.keepBranch) {
       // Delete the actual current branch

--- a/packages/cli/src/commands/list.test.ts
+++ b/packages/cli/src/commands/list.test.ts
@@ -48,6 +48,7 @@ describe('list', () => {
       path: '/fake/root',
       isShadow: false,
       isMain: true,
+      prunable: false,
     });
     expect(output[1]).toEqual({
       dirName: 'feat/test',
@@ -56,7 +57,21 @@ describe('list', () => {
       path: '/fake/root.worktrees/feat/test',
       isShadow: true,
       isMain: false,
+      prunable: false,
     });
+  });
+
+  it('should flag a worktree whose folder was deleted as prunable', async () => {
+    mockGitUtils.listWorktrees.mockResolvedValue([
+      'worktree /fake/root\nHEAD abc123\nbranch refs/heads/main',
+      `worktree /fake/root.worktrees/feat/gone\nHEAD def456\nbranch refs/heads/feat/gone\nprunable gitdir file points to non-existent location`,
+    ]);
+
+    await list({ root: rootDir, json: true });
+
+    const output = JSON.parse(consoleSpy.mock.calls[0][0]);
+    expect(output[0].prunable).toBe(false);
+    expect(output[1].prunable).toBe(true);
   });
 
   it('should strip refs/heads/ from branch names', async () => {

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -11,6 +11,7 @@ export interface ShadowClone {
   isShadow: boolean;
   isMain?: boolean;
   isDetached?: boolean;
+  prunable?: boolean;     // git reports the worktree dir is gone (folder deleted manually)
   baseBranch?: string;
   description?: string;
   reviewStatus?: ReviewStatus;
@@ -56,6 +57,9 @@ export function parseWorktrees(rawEntries: string[], _rootDir: string): ShadowCl
     const worktreePath = wtLine ? wtLine.substring('worktree '.length) : undefined;
     const branchRef = lines.find(l => l.startsWith('branch'))?.split(' ').pop();
     const isMain = i === 0;
+    // git marks an entry `prunable` when its worktree dir no longer exists
+    // (e.g. the user deleted the folder manually).
+    const prunable = lines.some(l => l.startsWith('prunable'));
 
     if (worktreePath && branchRef) {
       const currentBranch = branchRef.replace('refs/heads/', '');
@@ -67,6 +71,7 @@ export function parseWorktrees(rawEntries: string[], _rootDir: string): ShadowCl
         path: worktreePath,
         isShadow: !isMain,
         isMain,
+        prunable,
       });
     } else if (worktreePath && !branchRef) {
       // Detached HEAD (e.g. during rebase conflict) — derive branch from path
@@ -81,6 +86,7 @@ export function parseWorktrees(rawEntries: string[], _rootDir: string): ShadowCl
         isShadow: !isMain,
         isMain,
         isDetached: true,
+        prunable,
       });
     }
   }

--- a/packages/cli/src/commands/metadata.ts
+++ b/packages/cli/src/commands/metadata.ts
@@ -37,5 +37,8 @@ export async function writeMetadata(
   metadata: Record<string, CloneMetadata>,
 ): Promise<void> {
   const metaPath = path.join(getRepoStorageDir(rootDir), METADATA_FILE);
+  // The `.lumi/` storage dir may not exist yet (it no longer rides along with
+  // the `.worktrees/` container) — ensure it before writing.
+  await fs.ensureDir(path.dirname(metaPath));
   await fs.writeFile(metaPath, JSON.stringify(metadata, null, 2));
 }

--- a/packages/cli/src/commands/migration.test.ts
+++ b/packages/cli/src/commands/migration.test.ts
@@ -198,7 +198,9 @@ describe('migration', () => {
 
     it('should merge metadata files during migration', async () => {
       const legacyMetadata = path.join(legacyDir, '.lumi-metadata.json');
-      const newMetadata = path.join(repoStorageDir, '.lumi-metadata.json');
+      // migrateLegacyClones targets the `.worktrees/` intermediate; the later
+      // migrateMetadataToLumiDir hop moves it on to `.lumi/`.
+      const newMetadata = path.join(clonesDir, '.lumi-metadata.json');
 
       mockFs.existsSync.mockImplementation((p: string) => {
         if (p === legacyDir) return true;
@@ -241,7 +243,9 @@ describe('migration', () => {
 
     it('should migrate .prompts directory', async () => {
       const legacyPrompts = path.join(legacyDir, '.prompts');
-      const newPrompts = path.join(repoStorageDir, '.prompts');
+      // migrateLegacyClones targets the `.worktrees/` intermediate (project
+      // prompts are later moved to <root>/.prompts by the extension migration).
+      const newPrompts = path.join(clonesDir, '.prompts');
 
       mockFs.existsSync.mockImplementation((p: string) => {
         if (p === legacyDir) return true;

--- a/packages/cli/src/commands/migration.ts
+++ b/packages/cli/src/commands/migration.ts
@@ -25,6 +25,45 @@ export function hasLegacyClones(rootDir: string): boolean {
 }
 
 /**
+ * Migrate the centralized metadata file from its legacy location inside the
+ * transient `.worktrees/` container to the durable `<repoRoot>/.lumi/` storage
+ * dir. Idempotent — a no-op once migrated (or if there was nothing to migrate).
+ *
+ * This is the keystone that lets `.worktrees/` be deleted freely: durable
+ * metadata no longer lives inside the folder the user is free to remove.
+ *
+ * @returns true if a migration was performed.
+ */
+export async function migrateMetadataToLumiDir(rootDir: string): Promise<boolean> {
+  const oldPath = path.join(getClonesDir(rootDir), METADATA_FILE);
+  const newPath = path.join(getRepoStorageDir(rootDir), METADATA_FILE);
+
+  // Safety: if the two helpers ever resolve to the same place, nothing to do.
+  if (path.resolve(oldPath) === path.resolve(newPath)) return false;
+  if (!(await fs.pathExists(oldPath))) return false;
+
+  try {
+    await fs.ensureDir(path.dirname(newPath));
+    if (await fs.pathExists(newPath)) {
+      // Both exist — merge, with the new location taking precedence.
+      let merged: Record<string, any> = {};
+      try { merged = await fs.readJSON(newPath); } catch { /* unreadable → {} */ }
+      let legacy: Record<string, any> = {};
+      try { legacy = await fs.readJSON(oldPath); } catch { /* unreadable → {} */ }
+      merged = { ...legacy, ...merged };
+      await fs.writeJSON(newPath, merged, { spaces: 2 });
+      await fs.remove(oldPath);
+    } else {
+      await fs.move(oldPath, newPath);
+    }
+    return true;
+  } catch {
+    // Best-effort — never block the caller on a migration failure.
+    return false;
+  }
+}
+
+/**
  * Migrate all worktrees from the legacy `.shadow-clones/` directory
  * to the new external storage at `<repoRoot>.worktrees/`.
  *

--- a/packages/cli/src/commands/spawn.test.ts
+++ b/packages/cli/src/commands/spawn.test.ts
@@ -11,6 +11,7 @@ const { mockGitUtils, mockFs } = vi.hoisted(() => ({
     addWorktree: vi.fn(),
     addWorktreeExisting: vi.fn(),
     branchExists: vi.fn(),
+    pruneWorktrees: vi.fn(),
   },
   mockFs: {
     ensureDir: vi.fn(),
@@ -66,6 +67,7 @@ describe('spawn', () => {
     mockGitUtils.addWorktree.mockResolvedValue(undefined);
     mockGitUtils.addWorktreeExisting.mockResolvedValue(undefined);
     mockGitUtils.branchExists.mockResolvedValue(false);
+    mockGitUtils.pruneWorktrees.mockResolvedValue(undefined);
     mockFs.ensureDir.mockResolvedValue(undefined);
     // No longer need to mock pathExists for lumi-ops-id
     mockFs.readFile.mockResolvedValue('');

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { GitUtils } from '../utils/git';
 import { getClonesDir, getRepoStorageDir, METADATA_FILE } from '../constants';
+import { migrateMetadataToLumiDir } from './migration';
 import { registerRepo } from '../registry';
 import chalk from 'chalk';
 import { DEFAULT_MISSION_TEMPLATE } from '../missionDefaults';
@@ -17,6 +18,14 @@ export async function spawn(branchName: string, options: { root: string; descrip
     if (!(await git.hasCommits())) {
       throw new Error('Repository has no commits. Please make an initial commit before creating a Shadow Clone.');
     }
+
+    // 0a. One-time migration: move metadata out of the transient .worktrees/
+    //     container into the durable <repo>/.lumi/ storage dir (idempotent).
+    await migrateMetadataToLumiDir(rootDir);
+
+    // 0b. Defensive prune: clear stale .git/worktrees/ registrations left by a
+    //     manually-deleted folder, so re-spawning that branch name can't fail.
+    await git.pruneWorktrees();
 
     // 0. Resolve clones directory
 
@@ -42,6 +51,7 @@ export async function spawn(branchName: string, options: { root: string; descrip
 
     // 3. Persist base branch metadata (centralized)
     const repoStorageDir = getRepoStorageDir(rootDir);
+    await fs.ensureDir(repoStorageDir);
     const metadataPath = path.join(repoStorageDir, METADATA_FILE);
     let metadata: Record<string, { baseBranch?: string; description?: string }> = {};
     try { metadata = await fs.readJSON(metadataPath); } catch {}

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -28,11 +28,14 @@ export const METADATA_FILE = '.lumi-metadata.json';
  */
 export type ReviewStatus = 'todo' | 'inProgress' | 'done' | 'wontDo' | 'needsReview' | 'needsRevision';
 /**
- * Get the per-repo storage directory for metadata and prompts.
- * Now unified with the worktrees directory.
+ * Get the per-repo storage directory for durable Lumi-Ops state (metadata).
+ * Lives at `<repoRoot>/.lumi/` — decoupled from the transient `.worktrees/`
+ * container so the worktrees folder can be deleted freely without losing
+ * metadata. Already git-excluded via `ensureGitExclude` (`.lumi/` is in the
+ * exclude patterns), so it is never accidentally committed.
  */
 export function getRepoStorageDir(rootDir: string): string {
-  return getClonesDir(rootDir);
+  return path.join(path.resolve(rootDir), '.lumi');
 }
 
 /**

--- a/packages/extension/src/ShadowTreeProvider.test.ts
+++ b/packages/extension/src/ShadowTreeProvider.test.ts
@@ -38,8 +38,9 @@ vi.mock('fs', () => ({
   readFileSync: vi.fn(() => '{}'),
 }));
 
-import { ShadowItem } from './ShadowTreeProvider';
+import { ShadowItem, ShadowTreeProvider } from './ShadowTreeProvider';
 import type { EnrichedClone } from './ShadowTreeProvider';
+import { parseWorktrees, GitUtils } from '@lumi-ops/cli';
 
 const NONE = 0; // TreeItemCollapsibleState.None
 
@@ -189,5 +190,47 @@ describe('ShadowItem', () => {
       const item = new ShadowItem('main', NONE, makeClone({ dirName: 'root', currentBranch: 'main', path: '/repo', isShadow: false }), 'currentBranch', '/ext', undefined);
       expect(item.contextValue).toBe('currentBranch');
     });
+  });
+});
+
+describe('ShadowTreeProvider.getChildren — prunable self-tidy', () => {
+  const fakeBus = { onDidChange: () => ({ dispose() {} }) } as any;
+
+  function setup(clones: EnrichedClone[]) {
+    const gitInstance = {
+      listWorktrees: vi.fn(async () => ['raw']),
+      pruneWorktrees: vi.fn(async () => {}),
+      hasConflicts: vi.fn(async () => false),
+    };
+    (GitUtils as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => gitInstance);
+    (parseWorktrees as unknown as ReturnType<typeof vi.fn>).mockReturnValue(clones);
+    return gitInstance;
+  }
+
+  it('excludes prunable worktrees from the sidebar and prunes exactly once', async () => {
+    const git = setup([
+      makeClone({ dirName: 'root', currentBranch: 'main', branch: 'main', path: '/repo', isShadow: false, isMain: true }),
+      makeClone({ dirName: 'feat/gone', path: '/repo.worktrees/feat/gone', prunable: true }),
+      makeClone({ dirName: 'feat/live', path: '/repo.worktrees/feat/live' }),
+    ]);
+    const provider = new ShadowTreeProvider(['/repo'], '/ext', fakeBus);
+
+    const labels = (await provider.getChildren()).map(i => i.label);
+
+    expect(labels).toContain('feat/live');
+    expect(labels).not.toContain('feat/gone'); // ghost entry filtered out
+    expect(git.pruneWorktrees).toHaveBeenCalledTimes(1); // reconcile fired by the prunable entry
+  });
+
+  it('does not prune when nothing is prunable', async () => {
+    const git = setup([
+      makeClone({ dirName: 'root', currentBranch: 'main', branch: 'main', path: '/repo', isShadow: false, isMain: true }),
+      makeClone({ dirName: 'feat/live', path: '/repo.worktrees/feat/live' }),
+    ]);
+    const provider = new ShadowTreeProvider(['/repo'], '/ext', fakeBus);
+
+    await provider.getChildren();
+
+    expect(git.pruneWorktrees).not.toHaveBeenCalled(); // zero work in steady state
   });
 });

--- a/packages/extension/src/ShadowTreeProvider.ts
+++ b/packages/extension/src/ShadowTreeProvider.ts
@@ -195,7 +195,16 @@ export class ShadowTreeProvider implements vscode.TreeDataProvider<ShadowItem> {
         }
 
         const worktreesRaw = await git.listWorktrees();
-        const clones = parseWorktrees(worktreesRaw, workspaceRoot);
+        const parsed = parseWorktrees(worktreesRaw, workspaceRoot);
+
+        // Condition-driven self-tidy: git flags a worktree whose folder was
+        // deleted manually as `prunable`. Drop those from the list (no ghost
+        // entries) and reconcile git's stale registrations — but only when
+        // something is actually prunable, so steady-state refreshes do no work.
+        const clones = parsed.filter(c => !c.prunable);
+        if (parsed.some(c => c.prunable)) {
+          try { await git.pruneWorktrees(); } catch { /* best-effort */ }
+        }
 
         // Enrich with metadata (keyed by dirName) and repoRoot
         for (const clone of clones) {

--- a/packages/extension/src/WorktreeManagerPanel.ts
+++ b/packages/extension/src/WorktreeManagerPanel.ts
@@ -7,7 +7,8 @@ import {
   unregisterRepo,
   parseWorktrees,
   GitUtils,
-  getClonesDir,
+  getRepoStorageDir,
+  migrateMetadataToLumiDir,
   METADATA_FILE,
 } from '@lumi-ops/cli';
 import type { ShadowClone, RegisteredRepo } from '@lumi-ops/cli';
@@ -154,7 +155,7 @@ export class WorktreeManagerPanel {
           case 'cycleStatus':
             if (msg.branch && msg.rootDir) {
               const statusOrder = ['todo', 'inProgress', 'done', 'wontDo'];
-              const metaPath = path.join(getClonesDir(msg.rootDir), METADATA_FILE);
+              const metaPath = path.join(getRepoStorageDir(msg.rootDir), METADATA_FILE);
               let meta: Record<string, any> = {};
               try {
                 const raw = fs.readFileSync(metaPath, 'utf-8');
@@ -222,11 +223,14 @@ export class WorktreeManagerPanel {
         }
 
         await git.pruneWorktrees();
+        // Idempotent: migrate this repo's metadata to <root>/.lumi/ even if it
+        // was never opened as the active workspace (so the manager enriches it).
+        await migrateMetadataToLumiDir(repo.rootDir);
         const worktreesRaw = await git.listWorktrees();
         const clones = parseWorktrees(worktreesRaw, repo.rootDir);
 
         // Enrich with metadata
-        const metadataPath = path.join(getClonesDir(repo.rootDir), METADATA_FILE);
+        const metadataPath = path.join(getRepoStorageDir(repo.rootDir), METADATA_FILE);
         let metadata: Record<string, { baseBranch?: string; reviewStatus?: string }> = {};
         try {
           const raw = fs.readFileSync(metadataPath, 'utf-8');
@@ -267,7 +271,7 @@ export class WorktreeManagerPanel {
   private _metaDebounce: ReturnType<typeof setTimeout> | null = null;
 
   private _setupMetadataWatchers(repos: { name: string; rootDir: string }[]) {
-    const currentDirs = new Set(repos.map(r => getClonesDir(r.rootDir)));
+    const currentDirs = new Set(repos.map(r => getRepoStorageDir(r.rootDir)));
 
     // Skip if same set of dirs already watched
     if (currentDirs.size === this._watchedDirs.size &&

--- a/packages/extension/src/extension.ts
+++ b/packages/extension/src/extension.ts
@@ -277,7 +277,9 @@ Add JWT-based authentication to the Express.js API.
   // -- fs.watch for instant cross-window metadata (status) refresh --
   // Set up watchers for ALL resolved roots (multi-root support)
   for (const watchRoot of allRoots) {
-    const metadataDir = getClonesDir(watchRoot);
+    // Metadata now lives in <root>/.lumi/, not the transient .worktrees/ —
+    // watch the durable storage dir so deleting .worktrees can't break sync.
+    const metadataDir = getRepoStorageDir(watchRoot);
     try {
       if (!fs.existsSync(metadataDir)) {
         fs.mkdirSync(metadataDir, { recursive: true });

--- a/packages/extension/src/migrations.ts
+++ b/packages/extension/src/migrations.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { getRepoStorageDir, LUMI_OPS_HOME, hasLegacyClones, migrateLegacyClones } from '@lumi-ops/cli';
+import { getClonesDir, LUMI_OPS_HOME, hasLegacyClones, migrateLegacyClones, migrateMetadataToLumiDir } from '@lumi-ops/cli';
 
 /**
  * Run all one-time migrations during extension activation.
@@ -8,8 +8,24 @@ import { getRepoStorageDir, LUMI_OPS_HOME, hasLegacyClones, migrateLegacyClones 
  */
 export async function runMigrations(context: vscode.ExtensionContext, rootPath: string | undefined): Promise<void> {
   await migrateLegacyWorktrees(rootPath);
+  await migrateMetadataLocation(rootPath);
   await migrateGlobalPrompts(context);
   await migrateProjectPrompts(rootPath);
+}
+
+/**
+ * Move the centralized metadata file out of the transient `.worktrees/`
+ * container into the durable `<repoRoot>/.lumi/` storage dir. Runs after the
+ * legacy `.shadow-clones` → `.worktrees` migration (two-hop) and before the
+ * sidebar first reads metadata. Best-effort.
+ */
+async function migrateMetadataLocation(rootPath: string | undefined): Promise<void> {
+  if (!rootPath) return;
+  try {
+    await migrateMetadataToLumiDir(rootPath);
+  } catch {
+    // Best-effort — don't block activation
+  }
 }
 
 /**
@@ -60,7 +76,8 @@ async function migrateGlobalPrompts(context: vscode.ExtensionContext): Promise<v
 async function migrateProjectPrompts(rootPath: string | undefined): Promise<void> {
   if (!rootPath) return;
   try {
-    const legacyDir = vscode.Uri.file(path.join(getRepoStorageDir(rootPath), '.prompts'));
+    // Legacy project prompts lived inside the `.worktrees/` container.
+    const legacyDir = vscode.Uri.file(path.join(getClonesDir(rootPath), '.prompts'));
     const entries = await vscode.workspace.fs.readDirectory(legacyDir);
     if (entries.length === 0) return;
 

--- a/packages/extension/src/test/suite/autoStatus.test.ts
+++ b/packages/extension/src/test/suite/autoStatus.test.ts
@@ -75,15 +75,15 @@ suite('AutoStatus — setStatusIfApplicable', () => {
 
   setup(() => {
     // Create a temp directory that mimics a repo root.
-    // getRepoStorageDir(root) returns `${root}.worktrees`
+    // getRepoStorageDir(root) returns ${root}/.lumi
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lumi-test-'));
-    const storageDir = `${tmpDir}.worktrees`;
+    const storageDir = path.join(tmpDir, '.lumi');
     fs.mkdirSync(storageDir, { recursive: true });
   });
 
   teardown(() => {
     // Clean up temp dirs
-    const storageDir = `${tmpDir}.worktrees`;
+    const storageDir = path.join(tmpDir, '.lumi');
     const metadataPath = path.join(storageDir, '.lumi-metadata.json');
     try { fs.unlinkSync(metadataPath); } catch { /* ignore */ }
     try { fs.rmdirSync(storageDir); } catch { /* ignore */ }
@@ -91,12 +91,12 @@ suite('AutoStatus — setStatusIfApplicable', () => {
   });
 
   function writeMetadata(data: Record<string, any>) {
-    const metadataPath = path.join(`${tmpDir}.worktrees`, '.lumi-metadata.json');
+    const metadataPath = path.join(tmpDir, '.lumi', '.lumi-metadata.json');
     fs.writeFileSync(metadataPath, JSON.stringify(data, null, 2));
   }
 
   function readMetadata(): Record<string, any> {
-    const metadataPath = path.join(`${tmpDir}.worktrees`, '.lumi-metadata.json');
+    const metadataPath = path.join(tmpDir, '.lumi', '.lumi-metadata.json');
     return JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
   }
 

--- a/packages/mcp-server/src/state.ts
+++ b/packages/mcp-server/src/state.ts
@@ -10,6 +10,7 @@ import {
   getLumiOpsHome,
   readMetadata as cliReadMetadata,
   writeMetadata as cliWriteMetadata,
+  migrateMetadataToLumiDir,
 } from '@lumi-ops/cli';
 import type { ReviewStatus } from '@lumi-ops/cli';
 import { resolveMainRepoRoot } from './utils.js';
@@ -71,11 +72,29 @@ export function ensureRootDir(rootDir?: string): { content: { type: 'text'; text
   }
 }
 
+/**
+ * Idempotent: move this repo's metadata out of the legacy `.worktrees/`
+ * container into `<root>/.lumi/` before any read/write. The MCP server has no
+ * activation hook of its own (unlike the extension), so this chokepoint is how
+ * agents that drive the server standalone get migrated. Cheap no-op after the
+ * first move. Best-effort — never block a metadata access on it.
+ */
+async function ensureMetadataMigrated(root: string): Promise<void> {
+  if (!root) return;
+  try {
+    await migrateMetadataToLumiDir(root);
+  } catch {
+    /* best-effort */
+  }
+}
+
 /** Read metadata for the current repo (delegates to CLI).
  * @param rootDir - Optional override; defaults to serverState.rootDir.
  */
 export async function readMetadata(rootDir?: string) {
-  return cliReadMetadata(rootDir || serverState.rootDir);
+  const root = rootDir || serverState.rootDir;
+  await ensureMetadataMigrated(root);
+  return cliReadMetadata(root);
 }
 
 /** Write metadata for the current repo (delegates to CLI).
@@ -86,7 +105,9 @@ export async function writeMetadata(
   metadata: Record<string, { baseBranch?: string; description?: string; reviewStatus?: ReviewStatus; sourcePrompt?: string }>,
   rootDir?: string,
 ) {
-  return cliWriteMetadata(rootDir || serverState.rootDir, metadata);
+  const root = rootDir || serverState.rootDir;
+  await ensureMetadataMigrated(root);
+  return cliWriteMetadata(root, metadata);
 }
 
 /** List .md files in a directory, excluding subdirectories like _missions/. */

--- a/packages/mcp-server/src/tools.test.ts
+++ b/packages/mcp-server/src/tools.test.ts
@@ -64,6 +64,7 @@ const mocks = vi.hoisted(() => {
     },
     readMetadata: vi.fn().mockResolvedValue({}),
     writeMetadata: vi.fn().mockResolvedValue(undefined),
+    migrateMetadataToLumiDir: vi.fn().mockResolvedValue(false),
     setCloneStatus: vi.fn().mockResolvedValue(undefined),
     requestRevision: vi.fn().mockResolvedValue({ feedbackPath: '/mock/path' }),
     tool: toolFn,
@@ -99,6 +100,7 @@ vi.mock('@lumi-ops/cli', () => ({
   METADATA_FILE: '.lumi-metadata.json',
   readMetadata: (...args: any[]) => mocks.readMetadata(...args),
   writeMetadata: (...args: any[]) => mocks.writeMetadata(...args),
+  migrateMetadataToLumiDir: (...args: any[]) => mocks.migrateMetadataToLumiDir(...args),
   setCloneStatus: (...args: any[]) => mocks.setCloneStatus(...args),
   requestRevision: (...args: any[]) => mocks.requestRevision(...args),
 }));
@@ -1375,6 +1377,8 @@ describe('describe_clone tool', () => {
     expect(mocks.GitUtilsConstructor).toHaveBeenCalledWith(ALT_REPO);
     expect(mocks.parseWorktrees).toHaveBeenCalledWith(expect.anything(), ALT_REPO);
     expect(mocks.readMetadata).toHaveBeenCalledWith(ALT_REPO);
+    // The metadata read path migrates the resolved root out of .worktrees first.
+    expect(mocks.migrateMetadataToLumiDir).toHaveBeenCalledWith(ALT_REPO);
   });
 });
 


### PR DESCRIPTION
Lets users delete `.worktrees/` freely without losing state, and makes the tool tidy up after itself — no manual button.

## Why
Dogfooding showed the real need wasn't "auto-delete the empty folder on last kill" but: **(1)** a user should be able to delete `.worktrees/` directly without worry, and **(2)** the tool should reconcile leftover git/metadata state. The keystone insight: durable metadata lived *inside* the transient `.worktrees/` container, which is what made deletion unsafe.

Full design + decision log: `doc/worktree-folder-cleanup-design.md`.

## Phase 1 — decouple metadata (`a4548aa`)
- `getRepoStorageDir()` → `<root>/.lumi/` (was `=== .worktrees`); already git-excluded via `ensureGitExclude`, zero new gitignore work
- `migrateMetadataToLumiDir()`: idempotent one-time move, wired into extension activation, `spawn()`, and the WorktreeManager per-repo refresh
- watchers now watch `.lumi/` (not `.worktrees/`), so deleting the container can't break sync — and no longer eager-mkdirs `.worktrees`
- `spawn()` gains a defensive `git worktree prune`

## Phase 2 — condition-driven prune + self-tidy (`12e6d11`)
- `parseWorktrees()` parses git's `prunable` porcelain flag
- the sidebar **excludes prunable worktrees** (fixes a latent ghost-entry bug) and runs `git worktree prune` **only when something is actually prunable** — zero work in steady state
- `kill()` removes the empty `.worktrees/` container when no worktrees remain (safe now that metadata moved out)
- re-intents the former "never delete `.worktrees` root" tests to the new self-tidy contract

## Not in scope
- Branch deletion — deleting a worktree folder ≠ deleting the branch; the tool never touches branch lifecycle
- Phase 3 watcher hardening (`fs.watch` `.on('error')` for Linux/Windows) — deferred to a release-hardening pass

## Tests
CLI 170 pass, extension 128 pass (incl. new prunable-parse + ShadowTreeProvider filter coverage). Two failures are **pre-existing and unrelated** (verified on clean base): a locale-dependent e2e merge-CONFLICT assertion and a rootAgentMode rule-content test.

Reviewed by an adversarial multi-agent pass: verdict ship-ready, no correctness blockers; the one flagged gap (untested filter) is now covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)