### PR TITLE
chore: bump version to v0.6.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumi-ops/cli",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "Core logic for Lumi-Ops Shadow Clone Protocol",
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "lumi-ops",
   "displayName": "Lumi-Ops",
   "description": "The workflow protocol for AI-assisted parallel development. Spawn isolated tasks, track progress, and review before merging.",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "publisher": "ZunRenYao",
   "engines": {
     "vscode": "^1.85.0"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lumi-ops/mcp-server",
-  "version": "0.5.6",
+  "version": "0.6.0",
   "description": "MCP server for the Shadow Clone Protocol — Git Worktree automation for AI agents",
   "license": "GPL-3.0-or-later",
   "author": "ZunRenYao",


### PR DESCRIPTION
Version bump after publishing v0.6.0 to Open VSX and the VS Code Marketplace.

Created manually because the CI publish run failed at the npm publish step (expired `NPM_TOKEN`) before reaching the auto-bump step. The MCP server npm publish will be done separately once credentials are refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)