### PR TITLE
ci(publish): make publish job idempotent for safe re-runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,11 +36,13 @@ jobs:
       - name: Set version in package.json
         run: |
           cd packages/cli
-          npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
           cd ../extension
-          npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
           cd ../mcp-server
-          npm version ${{ steps.version.outputs.VERSION }} --no-git-tag-version
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -51,6 +53,8 @@ jobs:
       - name: Build MCP Server
         run: pnpm --filter @lumi-ops/mcp-server build
 
+      # skipDuplicate on marketplace steps + registry check on npm keep every
+      # publish step idempotent, so a partially failed run can be re-run safely.
       - name: Publish to Open VSX
         uses: HaaLeo/publish-vscode-extension@v2
         with:
@@ -58,6 +62,7 @@ jobs:
           registryUrl: https://open-vsx.org
           packagePath: packages/extension
           dependencies: false
+          skipDuplicate: true
 
       - name: Publish to VS Code Marketplace
         uses: HaaLeo/publish-vscode-extension@v2
@@ -66,17 +71,33 @@ jobs:
           registryUrl: https://marketplace.visualstudio.com
           packagePath: packages/extension
           dependencies: false
+          skipDuplicate: true
 
       - name: Publish MCP Server to npm
-        run: npm publish --access public
+        run: |
+          if npm view "@lumi-ops/mcp-server@${VERSION}" version >/dev/null 2>&1; then
+            echo "⏭ @lumi-ops/mcp-server@${VERSION} already on npm — skipping"
+          else
+            npm publish --access public
+          fi
         working-directory: packages/mcp-server
         env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create version bump PR
         run: |
-          VERSION=${{ steps.version.outputs.VERSION }}
           BRANCH="chore/bump-v${VERSION}"
+
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "⏭ Branch ${BRANCH} already exists — skipping bump PR"
+            exit 0
+          fi
+
+          if git diff --quiet -- packages/cli/package.json packages/extension/package.json packages/mcp-server/package.json; then
+            echo "⏭ Versions already at ${VERSION} on main — skipping bump PR"
+            exit 0
+          fi
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -92,4 +113,5 @@ jobs:
             --base main \
             --head "$BRANCH"
         env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

During the v0.6.0 release the `NPM_TOKEN` secret had expired, so the publish job failed at the npm step **after** the extension was already published to Open VSX and the VS Code Marketplace. The run could not be re-run: the marketplace steps would fail on the duplicate version before reaching the failed npm step, so the npm publish and the version-bump PR had to be done manually.

## What

Every step in the publish job is now idempotent, so a partially failed run can simply be re-run after fixing credentials:

- `skipDuplicate: true` on the Open VSX and VS Code Marketplace publish steps
- npm publish step checks the registry first and skips if the version already exists
- `npm version` uses `--allow-same-version` so re-runs survive an already-merged bump PR
- bump PR step exits early when its branch already exists or the versions on main are already current
- `VERSION` is passed via `env:` instead of being interpolated into `run:` scripts (safer against ref-name injection)

## Reminder

⚠️ The `NPM_TOKEN` repo secret is still expired — it must be replaced with a fresh granular token before the next release, or the npm step will fail again (this PR only makes the retry safe, it doesn't fix the credential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)