### PR TITLE
fix(kill): location-agnostic cleanup — self-tidy legacy .shadow-clones shells

### DIFF
--- a/doc/worktree-folder-cleanup-design.md
+++ b/doc/worktree-folder-cleanup-design.md
@@ -191,3 +191,43 @@ The crash matters for **Linux/Windows** users you ship to:
    re-spawnable).
 5. ⏳ OPEN: Phase 3 watcher hardening — bundle now, or separate release-hardening pass?
 6. ⏳ Per CLAUDE.md: design-only so far; **awaiting explicit go-ahead before any code.**
+
+## 7. Phase 2b — location-agnostic cleanup (legacy `.shadow-clones` self-tidy) — APPROVED 2026-07-08
+
+**Problem.** Killing a worktree at the legacy location (`<repo>/.shadow-clones/`)
+removes the worktree (post-#44) but skips all cleanup: step 2c
+(`kill.ts` parent-climb) and step 2d (empty-container removal) are both gated on
+`getClonesDir()` — the new `<repo>.worktrees` sibling — so legacy empty shells
+(`.shadow-clones/feat/` after killing `feat/x`, and the empty `.shadow-clones/`
+container itself) are left behind forever.
+
+**Design.** Derive the cleanup boundary from the actual `targetPath` instead of
+assuming the new location:
+
+- `resolveCleanupContainer(rootDir, targetPath)` → returns whichever known
+  container the target lives in — `getClonesDir(rootDir)` or
+  `<rootDir>/${SHADOW_CLONES_DIR}` — or `null` for a custom path outside both.
+  Match with `startsWith(container + path.sep)` (also fixes the pre-existing
+  unbounded `startsWith` that would confuse `/repo.worktrees-backup` with
+  `/repo.worktrees`).
+- Step 2c climbs within the resolved container; `null` → skip (no safe boundary).
+- Step 2d rules differ per container:
+  - `.worktrees` (new): unchanged — remove when no subdirectories remain
+    (stray files like `.DS_Store` are ignored; metadata is guaranteed in `.lumi/`).
+  - `.shadow-clones` (legacy): stricter — remove only when there are no
+    subdirectories **and** no files other than `.DS_Store`. The legacy container
+    may still hold an unmigrated `.lumi-metadata.json` (see `migration.ts`
+    legacy meta paths); the loose rule would delete it.
+- Hardening (same code path): call `migrateMetadataToLumiDir(rootDir)` at the
+  top of `kill()`. The CLI currently has this chokepoint only in `spawn()` —
+  a pure-CLI user who kills without ever spawning post-upgrade could still have
+  metadata inside `.worktrees/`, which step 2d would delete with the container.
+
+**Out of scope:** `deriveDirName` last-segment metadata-key mismatch for legacy
+nested branches; command-palette kill route losing `worktreePath`.
+
+**Tests** (`kill.test.ts`): legacy nested shell + container removed when empty;
+container kept while other clones remain; container kept when it still holds
+`.lumi-metadata.json`; custom out-of-container path → no climb, no removal;
+unmigrated `.worktrees` metadata survives kill via migration; existing suite
+unchanged as regression guard.

--- a/packages/cli/src/commands/kill.test.ts
+++ b/packages/cli/src/commands/kill.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as path from 'path';
 
 // --- Mocks (vi.hoisted ensures these are available when vi.mock factories run) ---
-const { mockGitUtils, mockFs, mockExecSync } = vi.hoisted(() => ({
+const { mockGitUtils, mockFs, mockExecSync, mockMigrate } = vi.hoisted(() => ({
   mockGitUtils: {
     removeWorktree: vi.fn(),
     deleteBranch: vi.fn(),
@@ -17,10 +17,15 @@ const { mockGitUtils, mockFs, mockExecSync } = vi.hoisted(() => ({
     remove: vi.fn(),
   },
   mockExecSync: vi.fn(),
+  mockMigrate: vi.fn(),
 }));
 
 vi.mock('../utils/git', () => ({
   GitUtils: vi.fn(() => mockGitUtils),
+}));
+
+vi.mock('./migration', () => ({
+  migrateMetadataToLumiDir: mockMigrate,
 }));
 
 vi.mock('fs-extra', () => ({
@@ -44,7 +49,7 @@ vi.mock('child_process', () => ({
 const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {}) as any);
 
 import { kill } from './kill';
-import { getClonesDir, getRepoStorageDir, METADATA_FILE } from '../constants';
+import { getClonesDir, getRepoStorageDir, METADATA_FILE, SHADOW_CLONES_DIR } from '../constants';
 
 describe('kill', () => {
   const identifier = 'feat/old-feature';
@@ -61,6 +66,7 @@ describe('kill', () => {
     mockFs.pathExists.mockResolvedValue(false);
     mockFs.remove.mockResolvedValue(undefined);
     mockFs.readdir.mockRejectedValue(new Error('ENOENT'));
+    mockMigrate.mockResolvedValue(false);
     // Default: actual branch matches identifier
     mockExecSync.mockReturnValue('feat/old-feature\n');
   });
@@ -345,5 +351,109 @@ describe('kill', () => {
     await kill(nestedIdentifier, { root: rootDir });
 
     expect(mockFs.remove).toHaveBeenCalledWith(parentPath);
+  });
+
+  // --- Legacy .shadow-clones cleanup tests (location-agnostic cleanup) ---
+
+  const legacyContainer = path.join(rootDir, SHADOW_CLONES_DIR);
+
+  it('should clean up empty parent shell and .shadow-clones container after killing a legacy-path worktree', async () => {
+    const legacyTarget = path.join(legacyContainer, 'feat', 'x');
+    const legacyParent = path.join(legacyContainer, 'feat');
+    mockExecSync.mockReturnValue('feat/x\n');
+    mockFs.readdir.mockImplementation(async (dir: string) => {
+      if (dir === legacyParent || dir === legacyContainer) return [];
+      throw new Error('ENOENT');
+    });
+
+    await kill('x', { root: rootDir, worktreePath: legacyTarget });
+
+    expect(mockGitUtils.removeWorktree).toHaveBeenCalledWith(legacyTarget, true);
+    expect(mockFs.remove).toHaveBeenCalledWith(legacyParent);
+    expect(mockFs.remove).toHaveBeenCalledWith(legacyContainer);
+  });
+
+  it('should NOT remove .shadow-clones while other legacy clones remain', async () => {
+    const legacyTarget = path.join(legacyContainer, 'gone');
+    mockExecSync.mockReturnValue('gone\n');
+    mockFs.readdir.mockImplementation(async (dir: string) => {
+      if (dir === legacyContainer) return [{ name: 'other', isDirectory: () => true }];
+      throw new Error('ENOENT');
+    });
+
+    await kill('gone', { root: rootDir, worktreePath: legacyTarget });
+
+    const removeCalls = mockFs.remove.mock.calls.map((c: any[]) => c[0]);
+    expect(removeCalls).not.toContain(legacyContainer);
+  });
+
+  it('should NOT remove .shadow-clones when an unmigrated metadata file remains inside', async () => {
+    const legacyTarget = path.join(legacyContainer, 'last-one');
+    mockExecSync.mockReturnValue('last-one\n');
+    mockFs.readdir.mockImplementation(async (dir: string) => {
+      if (dir === legacyContainer) return [{ name: METADATA_FILE, isDirectory: () => false }];
+      throw new Error('ENOENT');
+    });
+
+    await kill('last-one', { root: rootDir, worktreePath: legacyTarget });
+
+    const removeCalls = mockFs.remove.mock.calls.map((c: any[]) => c[0]);
+    expect(removeCalls).not.toContain(legacyContainer);
+  });
+
+  it('should remove .shadow-clones when only .DS_Store remains inside', async () => {
+    const legacyTarget = path.join(legacyContainer, 'last-one');
+    mockExecSync.mockReturnValue('last-one\n');
+    mockFs.readdir.mockImplementation(async (dir: string) => {
+      if (dir === legacyContainer) return [{ name: '.DS_Store', isDirectory: () => false }];
+      throw new Error('ENOENT');
+    });
+
+    await kill('last-one', { root: rootDir, worktreePath: legacyTarget });
+
+    expect(mockFs.remove).toHaveBeenCalledWith(legacyContainer);
+  });
+
+  it('should skip parent climb and container removal for a custom worktreePath outside known containers', async () => {
+    const customPath = '/elsewhere/my-worktree';
+    mockExecSync.mockReturnValue('mybranch\n');
+
+    await kill('mybranch', { root: rootDir, worktreePath: customPath });
+
+    expect(mockGitUtils.removeWorktree).toHaveBeenCalledWith(customPath, true);
+    // No known container boundary → cleanup never probes or removes directories
+    expect(mockFs.readdir).not.toHaveBeenCalled();
+    expect(mockFs.remove).not.toHaveBeenCalled();
+  });
+
+  it('should not treat a sibling directory sharing the .worktrees prefix as inside the container', async () => {
+    // /fake/root.worktrees-backup shares the raw string prefix of /fake/root.worktrees
+    const trickyPath = path.join(`${getClonesDir(rootDir)}-backup`, 'mybranch');
+    mockExecSync.mockReturnValue('mybranch\n');
+
+    await kill('mybranch', { root: rootDir, worktreePath: trickyPath });
+
+    expect(mockFs.readdir).not.toHaveBeenCalled();
+    expect(mockFs.remove).not.toHaveBeenCalled();
+  });
+
+  // --- Metadata migration chokepoint ---
+
+  it('should migrate metadata to .lumi/ before any container cleanup', async () => {
+    const clonesDir = getClonesDir(rootDir);
+    mockExecSync.mockReturnValue('mybranch\n');
+    mockFs.readdir.mockImplementation(async (dir: string) => {
+      if (dir === clonesDir) return [];
+      throw new Error('ENOENT');
+    });
+
+    await kill('mybranch', { root: rootDir });
+
+    expect(mockMigrate).toHaveBeenCalledWith(rootDir);
+    // Migration must run before the container is removed, or an unmigrated
+    // metadata file would be deleted with it
+    expect(mockMigrate.mock.invocationCallOrder[0]).toBeLessThan(
+      mockFs.remove.mock.invocationCallOrder[0],
+    );
   });
 });

--- a/packages/cli/src/commands/kill.ts
+++ b/packages/cli/src/commands/kill.ts
@@ -1,9 +1,25 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { GitUtils } from '../utils/git';
-import { getClonesDir, getRepoStorageDir, METADATA_FILE } from '../constants';
+import { getClonesDir, getRepoStorageDir, METADATA_FILE, SHADOW_CLONES_DIR } from '../constants';
+import { migrateMetadataToLumiDir } from './migration';
 import chalk from 'chalk';
 import { execSync } from 'child_process';
+
+/**
+ * Resolve which known clones container a worktree path lives in — the current
+ * `<repo>.worktrees` sibling or the legacy `<repo>/.shadow-clones` — so the
+ * post-kill cleanup can climb and self-tidy within the right boundary.
+ * Returns null for a path outside both: no known boundary means no cleanup.
+ */
+function resolveCleanupContainer(rootDir: string, targetPath: string): string | null {
+  const candidates = [
+    getClonesDir(rootDir),
+    path.join(path.resolve(rootDir), SHADOW_CLONES_DIR),
+  ];
+  const resolved = path.resolve(targetPath);
+  return candidates.find((dir) => resolved.startsWith(dir + path.sep)) ?? null;
+}
 
 export async function kill(identifier: string, options: { root: string; keepBranch?: boolean; worktreePath?: string }) {
   const rootDir = path.resolve(options.root);
@@ -12,6 +28,12 @@ export async function kill(identifier: string, options: { root: string; keepBran
 
   try {
     console.log(chalk.yellow(`🧨 Killing shadow clone: ${identifier}...`));
+
+    // 0. Move durable metadata out of the transient container before the
+    //    cleanup below can remove the folder it may still live in (a pure-CLI
+    //    user can reach kill without ever hitting the spawn/extension/MCP
+    //    migration chokepoints). Idempotent, best-effort.
+    await migrateMetadataToLumiDir(rootDir);
 
     // 1. Read the actual current branch before removing the worktree
     let actualBranch: string | undefined;
@@ -44,37 +66,48 @@ export async function kill(identifier: string, options: { root: string; keepBran
       console.log(chalk.gray('✓ Cleaned up residual clone directory.'));
     }
 
-    // 2c. Clean up empty parent directories left by nested branch names (e.g. feat/xxx)
-    const clonesDir = getClonesDir(rootDir);
-    let parentDir = path.dirname(targetPath);
-    while (parentDir !== clonesDir && parentDir.startsWith(clonesDir)) {
-      try {
-        const entries = await fs.readdir(parentDir, { withFileTypes: true });
-        const hasSubdirs = entries.some((e: { isDirectory: () => boolean }) => e.isDirectory());
-        if (!hasSubdirs) {
-          await fs.remove(parentDir);
-          parentDir = path.dirname(parentDir);
-        } else {
-          break; // Parent still has child directories (other clones), stop climbing
+    // 2c. Clean up empty parent directories left by nested branch names (e.g. feat/xxx).
+    //     The climb is bounded by whichever known container the target lives in —
+    //     the current .worktrees or the legacy .shadow-clones. A custom path
+    //     outside both has no safe boundary: no climb, no container removal.
+    const containerDir = resolveCleanupContainer(rootDir, targetPath);
+    if (containerDir) {
+      let parentDir = path.dirname(targetPath);
+      while (parentDir.startsWith(containerDir + path.sep)) {
+        try {
+          const entries = await fs.readdir(parentDir, { withFileTypes: true });
+          const hasSubdirs = entries.some((e: { isDirectory: () => boolean }) => e.isDirectory());
+          if (!hasSubdirs) {
+            await fs.remove(parentDir);
+            parentDir = path.dirname(parentDir);
+          } else {
+            break; // Parent still has child directories (other clones), stop climbing
+          }
+        } catch {
+          break; // Directory doesn't exist or not accessible, stop
         }
-      } catch {
-        break; // Directory doesn't exist or not accessible, stop
       }
     }
 
-    // 2d. Remove the empty .worktrees container itself when no worktrees remain.
-    //     Safe now that metadata lives in <root>/.lumi/, not inside .worktrees —
-    //     so "no worktree subdirs" means the folder is genuinely empty. Files
-    //     like .DS_Store are ignored and removed with the folder. Best-effort.
-    try {
-      const entries = await fs.readdir(clonesDir, { withFileTypes: true });
-      const hasSubdirs = entries.some((e: { isDirectory: () => boolean }) => e.isDirectory());
-      if (!hasSubdirs) {
-        await fs.remove(clonesDir);
-        console.log(chalk.gray('✓ Removed empty .worktrees container.'));
+    // 2d. Remove the empty container itself when no worktrees remain.
+    //     .worktrees is safe to drop with stray files inside (metadata lives in
+    //     <root>/.lumi/, so files like .DS_Store go with the folder). The legacy
+    //     .shadow-clones may still hold an unmigrated .lumi-metadata.json, so it
+    //     is only removed when nothing but .DS_Store remains. Best-effort.
+    if (containerDir) {
+      const isLegacyContainer = containerDir !== getClonesDir(rootDir);
+      try {
+        const entries = await fs.readdir(containerDir, { withFileTypes: true });
+        const hasSubdirs = entries.some((e: { isDirectory: () => boolean }) => e.isDirectory());
+        const hasBlockingFiles = isLegacyContainer &&
+          entries.some((e: { name: string; isDirectory: () => boolean }) => !e.isDirectory() && e.name !== '.DS_Store');
+        if (!hasSubdirs && !hasBlockingFiles) {
+          await fs.remove(containerDir);
+          console.log(chalk.gray(`✓ Removed empty ${isLegacyContainer ? SHADOW_CLONES_DIR : '.worktrees'} container.`));
+        }
+      } catch {
+        // Container already gone or unreadable — nothing to do
       }
-    } catch {
-      // .worktrees already gone or unreadable — nothing to do
     }
 
     // 3. Delete branch (unless keepBranch is set)


### PR DESCRIPTION
## Problem

Killing a worktree at the legacy `<repo>/.shadow-clones/` location removes the worktree itself (fixed by #44 → shipped in v0.6.0), but skips all post-kill tidying: the parent-climb (2c) and empty-container removal (2d) in `packages/cli/src/commands/kill.ts` were both hard-gated on `getClonesDir()` — the new `<repo>.worktrees` sibling. Legacy empty shells (`.shadow-clones/feat/` after killing `feat/x`, and the empty `.shadow-clones/` container itself) were left behind forever.

## Design

Approved plan recorded in `doc/worktree-folder-cleanup-design.md` §7. Core idea: **derive the cleanup boundary from the actual `targetPath`** instead of assuming the new location.

- `resolveCleanupContainer()` returns whichever known container the target lives in — `<repo>.worktrees` or legacy `<repo>/.shadow-clones` — or `null` for a custom path outside both (no safe boundary → no climb, no container removal).
- Per-container removal rules:
  - `.worktrees` (current): unchanged — removed when no subdirectories remain (stray `.DS_Store` goes with the folder).
  - `.shadow-clones` (legacy): stricter — removed only when nothing but `.DS_Store` remains, because it may still hold an **unmigrated `.lumi-metadata.json`** (one of the legacy meta paths in `migration.ts`).
- Fixes a latent boundary bug: the old `startsWith(clonesDir)` had no path-separator guard, so `/repo.worktrees-backup` was considered inside `/repo.worktrees`.

### Hardening (same code path)

`kill()` now calls `migrateMetadataToLumiDir()` up front (idempotent, best-effort). The CLI previously had this chokepoint only in `spawn()` — a pure-CLI user killing without ever spawning post-upgrade could have step 2d delete `.worktrees` with unmigrated metadata still inside.

## Out of scope

- `deriveDirName` last-segment metadata-key mismatch for legacy nested branches
- Command-palette kill route losing `worktreePath`

## Tests

7 new unit tests: legacy nested shell + container removal, container preserved while clones/metadata remain, `.DS_Store`-only removal, out-of-container path safety, sibling-prefix boundary, migration-before-cleanup ordering.

- CLI: 153/153 ✅ (tsc build clean)
- MCP server: 119/119 ✅
- VS Code integration: 140/140 ✅
- Extension vitest: 128/129 — the 1 red is the pre-existing `rootAgentMode.test.ts` content mismatch, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)