### PR TITLE
test(extension): update root-agent rule assertion to match coordinator template

### DIFF
--- a/packages/extension/src/rootAgentMode.test.ts
+++ b/packages/extension/src/rootAgentMode.test.ts
@@ -87,7 +87,7 @@ describe('registerRootAgentMode', () => {
       const content = mockWriteFile.mock.calls[0][1];
       expect(content).toContain('Root Agent Mode');
       expect(content).toContain('DO NOT implement code directly');
-      expect(content).toContain('.prompts/');
+      expect(content).toContain('Coordinator Protocol');
     });
 
     it('deletes rule file when disabled + root workspace', async () => {


### PR DESCRIPTION
Fixes the long-standing red test `rootAgentMode.test.ts > writes correct rule content`.

The root-agent rule template was rewritten in `7192124` (Agent Intelligence Upgrade, shipped in v0.5.6) and no longer mentions `.prompts/`, but the assertion still expected the v0.4.0 template content. Updated to assert on `Coordinator Protocol`, a stable heading of the current template. Test-only change — no product code touched.

Extension vitest: 129/129 ✅ (was 128/129)

🤖 Generated with [Claude Code](https://claude.com/claude-code)