### PR TITLE
fix(kill): resolve real worktree path from git when caller passes none

### DIFF
--- a/doc/worktree-folder-cleanup-design.md
+++ b/doc/worktree-folder-cleanup-design.md
@@ -231,3 +231,35 @@ container kept while other clones remain; container kept when it still holds
 `.lumi-metadata.json`; custom out-of-container path → no climb, no removal;
 unmigrated `.worktrees` metadata survives kill via migration; existing suite
 unchanged as regression guard.
+
+## 8. Kill target resolution via git (Option D) — APPROVED 2026-07-08
+
+**Problem.** Only the sidebar and the Worktree Manager pass the real worktree
+path into `kill()`. The other three routes — MCP `kill_clone`
+(`clone-ops.ts`), the command palette (no tree item → no `worktreePath`), and
+raw CLI — guess `<clonesDir>/<identifier>`. For a worktree at the legacy
+`.shadow-clones/` or any custom location, the kill half-fails (worktree not
+removed, prune no-op, branch delete refused because still checked out); if an
+unrelated directory happens to sit at the guessed path, step 2b removes it —
+a wrong-target deletion.
+
+**Design.** Fix at the CLI chokepoint so all callers benefit:
+`resolveWorktreePath(git, rootDir, identifier)` queries
+`git worktree list --porcelain` (via the existing `GitUtils.listWorktrees` +
+`parseWorktrees`) and resolves the identifier to the registered on-disk path:
+
+- Match order: exact checked-out **branch name** first (git guarantees
+  uniqueness), then derived **dirName** if exactly one worktree matches.
+- The **main worktree is never a candidate** (the repo root must never become
+  a kill target).
+- Ambiguous or no match → return null and keep the historical
+  `<clonesDir>/<identifier>` fallback. Porcelain failure (not a git repo) →
+  same fallback, never throws.
+- Explicit `options.worktreePath` still short-circuits everything.
+
+Composes with §7: the resolved path feeds `resolveCleanupContainer`, so legacy
+worktrees killed via MCP/palette/CLI now get the same self-tidy.
+
+**Behavior note.** A manually created worktree (outside any lumi container) is
+now resolvable by its branch name — consistent with the sidebar, which already
+lists every non-main worktree as a manageable clone.

--- a/packages/cli/src/commands/kill.test.ts
+++ b/packages/cli/src/commands/kill.test.ts
@@ -7,6 +7,7 @@ const { mockGitUtils, mockFs, mockExecSync, mockMigrate } = vi.hoisted(() => ({
     removeWorktree: vi.fn(),
     deleteBranch: vi.fn(),
     pruneWorktrees: vi.fn(),
+    listWorktrees: vi.fn(),
   },
   mockFs: {
     readJSON: vi.fn(),
@@ -61,6 +62,7 @@ describe('kill', () => {
     vi.clearAllMocks();
     mockGitUtils.removeWorktree.mockResolvedValue(undefined);
     mockGitUtils.deleteBranch.mockResolvedValue(undefined);
+    mockGitUtils.listWorktrees.mockResolvedValue([]);
     mockFs.readJSON.mockRejectedValue(new Error('ENOENT'));
     mockFs.writeJSON.mockResolvedValue(undefined);
     mockFs.pathExists.mockResolvedValue(false);
@@ -435,6 +437,76 @@ describe('kill', () => {
 
     expect(mockFs.readdir).not.toHaveBeenCalled();
     expect(mockFs.remove).not.toHaveBeenCalled();
+  });
+
+  // --- Worktree path resolution (no explicit worktreePath) ---
+
+  const mainEntry = `worktree ${rootDir}\nHEAD aaa\nbranch refs/heads/main`;
+
+  it('should resolve the real worktree path from git when the caller does not pass one', async () => {
+    const legacyPath = path.join(legacyContainer, 'feat', 'old-feature');
+    mockGitUtils.listWorktrees.mockResolvedValue([
+      mainEntry,
+      `worktree ${legacyPath}\nHEAD bbb\nbranch refs/heads/feat/old-feature`,
+    ]);
+
+    await kill(identifier, { root: rootDir });
+
+    expect(mockGitUtils.removeWorktree).toHaveBeenCalledWith(legacyPath, true);
+  });
+
+  it('should resolve by derived dirName when the identifier is not a branch name', async () => {
+    const legacyPath = path.join(legacyContainer, 'feat', 'x');
+    mockExecSync.mockReturnValue('feat/x\n');
+    mockGitUtils.listWorktrees.mockResolvedValue([
+      mainEntry,
+      `worktree ${legacyPath}\nHEAD bbb\nbranch refs/heads/feat/x`,
+    ]);
+
+    await kill('x', { root: rootDir });
+
+    expect(mockGitUtils.removeWorktree).toHaveBeenCalledWith(legacyPath, true);
+  });
+
+  it('should fall back to the default path when dirName matches are ambiguous', async () => {
+    mockExecSync.mockReturnValue('x\n');
+    mockGitUtils.listWorktrees.mockResolvedValue([
+      mainEntry,
+      `worktree ${path.join(legacyContainer, 'feat', 'x')}\nHEAD bbb\nbranch refs/heads/feat/x`,
+      `worktree ${path.join(legacyContainer, 'fix', 'x')}\nHEAD ccc\nbranch refs/heads/fix/x`,
+    ]);
+
+    await kill('x', { root: rootDir });
+
+    expect(mockGitUtils.removeWorktree).toHaveBeenCalledWith(
+      path.join(getClonesDir(rootDir), 'x'), true,
+    );
+  });
+
+  it('should never resolve the identifier to the main worktree', async () => {
+    mockExecSync.mockReturnValue('main\n');
+    mockGitUtils.listWorktrees.mockResolvedValue([mainEntry]);
+
+    await kill('main', { root: rootDir });
+
+    // Falls back to the guessed clone path — the repo root is never a kill target
+    expect(mockGitUtils.removeWorktree).toHaveBeenCalledWith(
+      path.join(getClonesDir(rootDir), 'main'), true,
+    );
+  });
+
+  it('should not query git for worktrees when an explicit worktreePath is supplied', async () => {
+    await kill(identifier, { root: rootDir, worktreePath: targetPath });
+
+    expect(mockGitUtils.listWorktrees).not.toHaveBeenCalled();
+  });
+
+  it('should fall back gracefully when git worktree listing fails', async () => {
+    mockGitUtils.listWorktrees.mockRejectedValue(new Error('not a git repo'));
+
+    await kill(identifier, { root: rootDir });
+
+    expect(mockGitUtils.removeWorktree).toHaveBeenCalledWith(targetPath, true);
   });
 
   // --- Metadata migration chokepoint ---

--- a/packages/cli/src/commands/kill.ts
+++ b/packages/cli/src/commands/kill.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra';
 import { GitUtils } from '../utils/git';
 import { getClonesDir, getRepoStorageDir, METADATA_FILE, SHADOW_CLONES_DIR } from '../constants';
 import { migrateMetadataToLumiDir } from './migration';
+import { parseWorktrees } from './list';
 import chalk from 'chalk';
 import { execSync } from 'child_process';
 
@@ -21,10 +22,36 @@ function resolveCleanupContainer(rootDir: string, targetPath: string): string | 
   return candidates.find((dir) => resolved.startsWith(dir + path.sep)) ?? null;
 }
 
+/**
+ * Resolve the real on-disk worktree path for an identifier by asking git.
+ * Callers that don't know the path (MCP kill_clone, the command palette,
+ * raw CLI) previously guessed `<clonesDir>/<identifier>`, which misses
+ * worktrees at the legacy .shadow-clones or any custom location — and could
+ * even hit an unrelated directory sitting at the guessed path. Matches the
+ * checked-out branch name first (unique per git), then the derived dirName
+ * when exactly one worktree matches; the main worktree is never a candidate.
+ * Returns null when nothing matches unambiguously — the caller keeps the
+ * historical fallback.
+ */
+async function resolveWorktreePath(git: GitUtils, rootDir: string, identifier: string): Promise<string | null> {
+  try {
+    const entries = await git.listWorktrees();
+    const clones = parseWorktrees(entries, rootDir).filter((c) => !c.isMain);
+    const byBranch = clones.find((c) => c.currentBranch === identifier);
+    if (byBranch) return byBranch.path;
+    const byDirName = clones.filter((c) => c.dirName === identifier);
+    return byDirName.length === 1 ? byDirName[0].path : null;
+  } catch {
+    return null; // porcelain unavailable — keep the fallback path
+  }
+}
+
 export async function kill(identifier: string, options: { root: string; keepBranch?: boolean; worktreePath?: string }) {
   const rootDir = path.resolve(options.root);
   const git = new GitUtils(rootDir);
-  const targetPath = options.worktreePath || path.join(getClonesDir(rootDir), identifier);
+  const targetPath = options.worktreePath
+    || (await resolveWorktreePath(git, rootDir, identifier))
+    || path.join(getClonesDir(rootDir), identifier);
 
   try {
     console.log(chalk.yellow(`🧨 Killing shadow clone: ${identifier}...`));


### PR DESCRIPTION
## Problem

Only two of the five kill routes pass the real worktree path into the CLI `kill()`: the sidebar tree item and the Worktree Manager. The other three — **MCP `kill_clone`** (`clone-ops.ts` calls `kill(branch, { root, keepBranch })` with no path), the **command palette** (no tree item → no `worktreePath`), and **raw CLI** — fall back to guessing `<clonesDir>/<identifier>`.

For a worktree at the legacy `.shadow-clones/` or any custom location, that guess makes the kill half-fail: the worktree isn't removed, `prune` is a no-op (the worktree is healthy), and the branch delete is refused because it's still checked out. Worse, if an unrelated directory happens to sit at the guessed path, the residual-cleanup step removes it — a wrong-target deletion.

## Fix

One change at the CLI chokepoint so all callers benefit: `kill()` now resolves the identifier to the **registered on-disk path** via `git worktree list --porcelain` (reusing `GitUtils.listWorktrees` + `parseWorktrees`):

- Exact **branch-name** match first (git guarantees a branch is checked out in at most one worktree), then derived **dirName** when exactly one worktree matches.
- The **main worktree is never a candidate** — the repo root can never become a kill target.
- Ambiguous / no match / porcelain failure → historical `<clonesDir>/<identifier>` fallback, never throws.
- An explicit `options.worktreePath` (sidebar, Worktree Manager) short-circuits — zero behavior change on those routes.

Composes with #51: the resolved path feeds `resolveCleanupContainer`, so legacy worktrees killed via MCP/palette/CLI now also get the self-tidy cleanup.

Design recorded in `doc/worktree-folder-cleanup-design.md` §8 (approved 2026-07-08).

## Behavior note

A manually created worktree outside any lumi container is now resolvable (and killable) by its branch name — consistent with the sidebar, which already lists every non-main worktree as a manageable clone.

## Tests

6 new unit tests: branch-name resolution, dirName resolution, ambiguity fallback, main-worktree exclusion, explicit-path short-circuit, porcelain-failure fallback.

- CLI: 159/159 ✅ (tsc build clean)
- MCP server: 119/119 ✅
- VS Code integration: 140/140 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)