### PR TITLE
fix(merge): detect conflicts via unmerged paths, not localized messages

### DIFF
--- a/packages/cli/src/commands/merge.test.ts
+++ b/packages/cli/src/commands/merge.test.ts
@@ -36,7 +36,17 @@ describe('merge', () => {
     vi.clearAllMocks();
     mockGitUtils.mergeSquash.mockResolvedValue(undefined);
     mockGitUtils.commit.mockResolvedValue(undefined);
+    // Default: the unmerged-paths probe reports a clean state
+    mockExecSync.mockReturnValue('');
   });
+
+  /** Make the `git diff --diff-filter=U` probe report unmerged (conflicted) files. */
+  function probeReportsConflicts() {
+    mockExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes('--diff-filter=U')) return 'src/conflicted-file.ts\n';
+      return '';
+    });
+  }
 
   // --- Basic merge (no cwd, legacy fallback) ---
 
@@ -84,16 +94,51 @@ describe('merge', () => {
 
   // --- Conflict handling ---
 
-  it('should throw CONFLICT error when merge has conflicts', async () => {
+  it('should throw CONFLICT when git reports unmerged paths', async () => {
+    probeReportsConflicts();
     mockGitUtils.mergeSquash.mockRejectedValue(new Error('CONFLICT (content): merge conflict in file.ts'));
 
     await expect(merge(branchName, options)).rejects.toThrow('CONFLICT');
   });
 
-  it('should throw CONFLICT error for lowercase conflict message', async () => {
+  it('should throw CONFLICT on a localized error message when git reports unmerged paths', async () => {
+    probeReportsConflicts();
+    // git localizes its messages — e.g. zh_TW says 「合併衝突」, no 'conflict' substring
+    mockGitUtils.mergeSquash.mockRejectedValue(new Error('自動合併失敗；請修正後再提交結果。'));
+
+    await expect(merge(branchName, options)).rejects.toThrow('CONFLICT');
+  });
+
+  it('should probe unmerged paths in the merge directory', async () => {
+    probeReportsConflicts();
+    mockGitUtils.mergeSquash.mockRejectedValue(new Error('whatever'));
+
+    await expect(
+      merge(branchName, { ...options, cwd: '/fake/worktree/develop' }),
+    ).rejects.toThrow('CONFLICT');
+
+    expect(mockExecSync).toHaveBeenCalledWith(
+      'git diff --name-only --diff-filter=U',
+      expect.objectContaining({ cwd: '/fake/worktree/develop' }),
+    );
+  });
+
+  it('should fall back to the message heuristic when the probe cannot run', async () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('spawn git ENOENT');
+    });
     mockGitUtils.mergeSquash.mockRejectedValue(new Error('Automatic merge failed; fix conflict'));
 
     await expect(merge(branchName, options)).rejects.toThrow('CONFLICT');
+  });
+
+  it('should trust the probe over the message when git reports no unmerged paths', async () => {
+    // Probe runs and reports clean → a message that merely mentions conflict
+    // is not treated as one (e.g. a failure about a file named CONFLICT)
+    const originalError = new Error('fatal: pathspec CONFLICT.md did not match any files');
+    mockGitUtils.mergeSquash.mockRejectedValue(originalError);
+
+    await expect(merge(branchName, options)).rejects.toThrow(originalError);
   });
 
   it('should re-throw non-conflict errors', async () => {

--- a/packages/cli/src/commands/merge.ts
+++ b/packages/cli/src/commands/merge.ts
@@ -3,6 +3,24 @@ import { execSync } from 'child_process';
 import { GitUtils } from '../utils/git';
 import chalk from 'chalk';
 
+/**
+ * Detect an in-progress merge conflict structurally via git's unmerged-paths
+ * listing. Parsing the human-readable error for "CONFLICT" breaks on
+ * non-English locales (git localizes its messages), which silently downgraded
+ * real conflicts to generic failures — and broke the MCP merge_clone flow
+ * that relies on the thrown 'CONFLICT' marker to return conflict context.
+ * Returns null when the check itself can't run; callers then fall back to the
+ * message heuristic.
+ */
+function hasUnmergedPaths(cwd: string): boolean | null {
+  try {
+    const output = execSync('git diff --name-only --diff-filter=U', { cwd, encoding: 'utf-8' });
+    return (output || '').trim().length > 0;
+  } catch {
+    return null;
+  }
+}
+
 export async function merge(branchName: string, options: {
   root: string;
   commitMessage?: string;
@@ -35,8 +53,13 @@ export async function merge(branchName: string, options: {
   } catch (error: any) {
     const errorMsg = error.message || '';
 
-    // Handle Conflicts
-    if (errorMsg.includes('CONFLICT') || errorMsg.toLowerCase().includes('conflict')) {
+    // Handle Conflicts — ask git for unmerged paths (locale-independent);
+    // the message heuristic is only a fallback when that check can't run.
+    const unmerged = hasUnmergedPaths(mergeDir);
+    const isConflict = unmerged !== null
+      ? unmerged
+      : (errorMsg.includes('CONFLICT') || errorMsg.toLowerCase().includes('conflict'));
+    if (isConflict) {
       console.error(chalk.yellow(`\n⚠️  Merge Conflict detected.`));
       throw new Error('CONFLICT');
     }


### PR DESCRIPTION
## Problem (C-1)

`merge.ts` decided "is this failure a conflict?" by matching `CONFLICT`/`conflict` in the error message. Git **localizes** those messages — under a non-English locale (e.g. `zh_TW`, where git prints 「衝突」) the match silently fails and a real conflict is reported as a generic merge failure. Downstream, MCP `merge_clone` (`clone-ops.ts:373`) checks `mergeError.message === 'CONFLICT'` to return structured conflict context (conflicted file list, diff stats) — so on non-English machines the agent-facing conflict-resolution flow broke entirely. English-locale CI can never catch this.

## Fix

Detect conflicts **structurally**: after a failed squash merge, probe `git diff --name-only --diff-filter=U` in the merge directory (fixed command string, nothing interpolated).

- Unmerged paths present → conflict (regardless of message language)
- Probe runs clean → genuine failure, original error re-thrown (a message merely *mentioning* CONFLICT no longer false-positives)
- Probe itself can't run → fall back to the old message heuristic
- The thrown `'CONFLICT'` marker contract is unchanged — MCP flow untouched

## Tests

4 new/updated conflict-detection tests, including the regression case: **localized (Chinese) error message + unmerged paths → CONFLICT**. Also covers probe-in-correct-cwd, probe-failure fallback, and probe-over-message precedence.

- CLI: 162/162 ✅ (tsc build clean; e2e real-git conflict test passes via the structural path)
- MCP server: 119/119 ✅ (CONFLICT contract intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)