### PR TITLE
fix(list): derive full dirName for legacy paths + metadata-key fallback on kill

### DIFF
--- a/doc/worktree-folder-cleanup-design.md
+++ b/doc/worktree-folder-cleanup-design.md
@@ -263,3 +263,20 @@ worktrees killed via MCP/palette/CLI now get the same self-tidy.
 **Behavior note.** A manually created worktree (outside any lumi container) is
 now resolvable by its branch name — consistent with the sidebar, which already
 lists every non-main worktree as a manageable clone.
+
+## 9. Legacy dirName identity + metadata-key fallback — APPROVED 2026-07-08
+
+**Problem.** `deriveDirName` (list.ts) only recognized the `.worktrees/`
+marker; legacy paths fell back to the *last path segment*, so
+`.shadow-clones/feat/x` derived `'x'` instead of `'feat/x'`. Metadata is keyed
+by the full spawn-time identifier → kill's metadata cleanup missed the entry,
+leaving a stale record and an undeleted generated prompt. `feat/x` and `fix/x`
+also collided on the same identity `'x'`.
+
+**Fix.**
+- `deriveDirName` recognizes both container markers (`.worktrees/`,
+  `.shadow-clones/`) and extracts the full relative suffix; last-segment
+  fallback remains only for paths outside both.
+- `kill()` step 4: when `metadata[identifier]` misses, fall back to the
+  **actual checked-out branch name** (read via rev-parse before removal) —
+  covers historical mismatches already sitting in metadata files.

--- a/packages/cli/src/commands/kill.test.ts
+++ b/packages/cli/src/commands/kill.test.ts
@@ -116,6 +116,38 @@ describe('kill', () => {
     );
   });
 
+  it('should clean up metadata by actual branch name when identifier key is missing', async () => {
+    // Legacy nested clone: caller passes last-segment dirName 'x', but the
+    // metadata entry is keyed by the spawn-time identifier 'feat/x'
+    mockExecSync.mockReturnValue('feat/x\n');
+    mockFs.readJSON.mockResolvedValue({
+      'feat/x': { baseBranch: 'main', sourcePrompt: '_generated/x.md' },
+      'feat/other': { baseBranch: 'main' },
+    });
+
+    await kill('x', { root: rootDir, worktreePath: path.join(rootDir, SHADOW_CLONES_DIR, 'feat', 'x') });
+
+    expect(mockFs.unlinkSync).toHaveBeenCalledWith(
+      path.join(rootDir, '.prompts', '_generated/x.md'),
+    );
+    expect(mockFs.writeJSON).toHaveBeenCalledWith(
+      metadataPath,
+      { 'feat/other': { baseBranch: 'main' } },
+      { spaces: 2 },
+    );
+  });
+
+  it('should NOT touch metadata when neither identifier nor actual branch matches', async () => {
+    mockExecSync.mockReturnValue('feat/unrelated\n');
+    mockFs.readJSON.mockResolvedValue({
+      'feat/other': { baseBranch: 'main' },
+    });
+
+    await kill('nonexistent', { root: rootDir });
+
+    expect(mockFs.writeJSON).not.toHaveBeenCalled();
+  });
+
   it('should not fail when metadata file does not exist', async () => {
     mockFs.readJSON.mockRejectedValue(new Error('ENOENT'));
 
@@ -455,25 +487,28 @@ describe('kill', () => {
     expect(mockGitUtils.removeWorktree).toHaveBeenCalledWith(legacyPath, true);
   });
 
-  it('should resolve by derived dirName when the identifier is not a branch name', async () => {
+  it('should resolve by derived dirName when the branch has drifted', async () => {
+    // Worktree created as feat/x, but a different branch is now checked out —
+    // dirName (full relative suffix under the legacy container) still matches
     const legacyPath = path.join(legacyContainer, 'feat', 'x');
-    mockExecSync.mockReturnValue('feat/x\n');
+    mockExecSync.mockReturnValue('develop\n');
     mockGitUtils.listWorktrees.mockResolvedValue([
       mainEntry,
-      `worktree ${legacyPath}\nHEAD bbb\nbranch refs/heads/feat/x`,
+      `worktree ${legacyPath}\nHEAD bbb\nbranch refs/heads/develop`,
     ]);
 
-    await kill('x', { root: rootDir });
+    await kill('feat/x', { root: rootDir });
 
     expect(mockGitUtils.removeWorktree).toHaveBeenCalledWith(legacyPath, true);
   });
 
   it('should fall back to the default path when dirName matches are ambiguous', async () => {
+    // Out-of-container worktrees derive last-segment dirNames, which can collide
     mockExecSync.mockReturnValue('x\n');
     mockGitUtils.listWorktrees.mockResolvedValue([
       mainEntry,
-      `worktree ${path.join(legacyContainer, 'feat', 'x')}\nHEAD bbb\nbranch refs/heads/feat/x`,
-      `worktree ${path.join(legacyContainer, 'fix', 'x')}\nHEAD ccc\nbranch refs/heads/fix/x`,
+      `worktree /elsewhere/a/x\nHEAD bbb\nbranch refs/heads/feat/x`,
+      `worktree /elsewhere/b/x\nHEAD ccc\nbranch refs/heads/fix/x`,
     ]);
 
     await kill('x', { root: rootDir });

--- a/packages/cli/src/commands/kill.ts
+++ b/packages/cli/src/commands/kill.ts
@@ -161,13 +161,20 @@ export async function kill(identifier: string, options: { root: string; keepBran
       console.log(chalk.gray(`✓ Branch(es) preserved.`));
     }
 
-    // 4. Clean up generated prompt + remove entry from centralized metadata
+    // 4. Clean up generated prompt + remove entry from centralized metadata.
+    //    Metadata is keyed by the spawn-time identifier; when the caller's
+    //    identifier doesn't match (e.g. a last-segment dirName derived from a
+    //    legacy path), fall back to the actual branch name so the entry and
+    //    its generated prompt don't go stale.
     const metadataPath = path.join(getRepoStorageDir(rootDir), METADATA_FILE);
     try {
       const metadata = await fs.readJSON(metadataPath);
-      if (metadata[identifier]) {
+      const metadataKey = metadata[identifier]
+        ? identifier
+        : (actualBranch && metadata[actualBranch] ? actualBranch : undefined);
+      if (metadataKey) {
         // Delete generated prompt file if tracked
-        const sourcePrompt = metadata[identifier].sourcePrompt;
+        const sourcePrompt = metadata[metadataKey].sourcePrompt;
         if (sourcePrompt && sourcePrompt.startsWith('_generated/')) {
           const promptPath = path.join(rootDir, '.prompts', sourcePrompt);
           try {
@@ -177,7 +184,7 @@ export async function kill(identifier: string, options: { root: string; keepBran
             // Already gone — that's fine
           }
         }
-        delete metadata[identifier];
+        delete metadata[metadataKey];
         await fs.writeJSON(metadataPath, metadata, { spaces: 2 });
         console.log(chalk.gray('✓ Cleaned up metadata.'));
       }

--- a/packages/cli/src/commands/list.test.ts
+++ b/packages/cli/src/commands/list.test.ts
@@ -215,7 +215,26 @@ describe('parseWorktrees', () => {
     expect(result[1].branch).toBe('develop');  // backward compat alias
   });
 
-  it('falls back to last path segment for non-.worktrees/ paths', () => {
+  it('derives full nested dirName from legacy .shadow-clones/ paths', () => {
+    const result = parseWorktrees([
+      'worktree /repo\nHEAD abc\nbranch refs/heads/main',
+      'worktree /repo/.shadow-clones/feat/my-task\nHEAD def\nbranch refs/heads/feat/my-task',
+    ], '/repo');
+
+    // Full identity, not last segment — metadata is keyed by `feat/my-task`
+    expect(result[1].dirName).toBe('feat/my-task');
+  });
+
+  it('derives flat dirName from legacy .shadow-clones/ paths', () => {
+    const result = parseWorktrees([
+      'worktree /repo\nHEAD abc\nbranch refs/heads/main',
+      'worktree /repo/.shadow-clones/my-task\nHEAD def\nbranch refs/heads/my-task',
+    ], '/repo');
+
+    expect(result[1].dirName).toBe('my-task');
+  });
+
+  it('falls back to last path segment for paths outside known containers', () => {
     const result = parseWorktrees([
       'worktree /repo\nHEAD abc\nbranch refs/heads/main',
       'worktree /completely/different/my-clone\nHEAD def\nbranch refs/heads/feat/a',

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { GitUtils } from '../utils/git';
+import { SHADOW_CLONES_DIR } from '../constants';
 import type { ReviewStatus } from '../constants';
 import chalk from 'chalk';
 
@@ -22,16 +23,23 @@ export interface ShadowClone {
 /**
  * Derive the stable `dirName` identity from a worktree path.
  *
- * For worktrees under `.worktrees/`: extracts the relative path suffix.
- *   e.g., `/repo.worktrees/feat/my-task` → `feat/my-task`
+ * For worktrees under a known container — current `.worktrees/` or legacy
+ * `.shadow-clones/` — extracts the relative path suffix, so nested branch
+ * names keep their full identity:
+ *   `/repo.worktrees/feat/my-task`      → `feat/my-task`
+ *   `/repo/.shadow-clones/feat/my-task` → `feat/my-task`
+ * (metadata is keyed by that full identifier — a last-segment `my-task`
+ * would orphan the entry on kill).
  *
- * Fallback for paths NOT under `.worktrees/`: uses the last path segment.
+ * Fallback for paths outside both containers: the last path segment.
  */
 function deriveDirName(worktreePath: string): string {
-  const marker = '.worktrees/';
-  const idx = worktreePath.indexOf(marker);
-  if (idx !== -1) {
-    return worktreePath.substring(idx + marker.length);
+  const markers = ['.worktrees/', `${SHADOW_CLONES_DIR}/`];
+  for (const marker of markers) {
+    const idx = worktreePath.indexOf(marker);
+    if (idx !== -1) {
+      return worktreePath.substring(idx + marker.length);
+    }
   }
   // Fallback: last path segment
   const segments = worktreePath.split('/');


### PR DESCRIPTION
## Problem

`deriveDirName` (`list.ts`) only recognized the `.worktrees/` marker. Legacy paths fell back to the **last path segment**: `.shadow-clones/feat/x` derived `'x'` instead of `'feat/x'`. Since metadata is keyed by the full spawn-time identifier:

- kill's metadata cleanup looked up `metadata['x']`, missed, and left a **stale metadata entry + an undeleted generated prompt**
- `feat/x` and `fix/x` collided on the same identity `'x'`

## Fix

1. **`deriveDirName` is container-aware**: recognizes both `.worktrees/` and legacy `.shadow-clones/` markers and extracts the full relative suffix (`feat/x`). Last-segment fallback remains only for paths outside both containers.
2. **`kill()` metadata fallback**: when `metadata[identifier]` misses, retry with the **actual checked-out branch name** (already read via rev-parse before removal). This also cleans up historical mismatches sitting in existing metadata files.

Design recorded in `doc/worktree-folder-cleanup-design.md` §9.

## Test note

Two #53 resolution tests had the old last-segment derivation baked into their premise (`kill('x')` matching a legacy `feat/x` worktree). Reworked to test the same code paths under the corrected derivation: dirName resolution via a **drifted-branch** scenario, ambiguity via **out-of-container** colliding paths. New coverage: legacy nested/flat derivation in `list.test.ts`, metadata cleanup by actual branch, and no-touch when neither key matches.

- CLI: 163/163 ✅ (tsc build clean)
- MCP server: 119/119 ✅
- Extension vitest: 129/129 ✅
- VS Code integration: 140/140 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)